### PR TITLE
feat: implement single-lining multi-line nodes

### DIFF
--- a/lua/treesitter-context/utils.lua
+++ b/lua/treesitter-context/utils.lua
@@ -1,0 +1,30 @@
+--
+-- utils.lua
+--
+
+
+local function slice(tbl, first, last)
+  if type(tbl) == 'string' then
+    return string.sub(tbl, first, last)
+  end
+
+  if first < 0 then
+    first = #tbl + 1 + first
+  end
+
+  if last ~= nil and last < 0 then
+    last = #tbl + 1 + last
+  end
+
+  local sliced = {}
+
+  for i = first or 1, last or #tbl do
+    sliced[#sliced+1] = tbl[i]
+  end
+
+  return sliced
+end
+
+return {
+  slice = slice,
+}


### PR DESCRIPTION
This PR implements single-lining of multi-line nodes. The implementation requires to know language-specific details (at which node to stop single-lining), otherwise the default behavior is displaying the first line only. Currenty only a few languages are supported, if yours isn't working send a PR or open an issue.


| code | context |
|--------|-----------|
| ![Screenshot from 2021-03-10 00-57-50](https://user-images.githubusercontent.com/1423607/110583489-c1d5cd00-813b-11eb-83f3-779aab168a8b.png) | ![Screenshot from 2021-03-10 00-57-57](https://user-images.githubusercontent.com/1423607/110583490-c1d5cd00-813b-11eb-8b14-96b55e89cefe.png) |
