### PR TITLE
Add option line_numbers to show line numbers of the context items

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ require'treesitter-context'.setup{
     enable = true, -- Enable this plugin (Can be enabled/disabled later via commands)
     throttle = true, -- Throttles plugin updates (may improve performance)
     max_lines = 0, -- How many lines the window should span. Values <= 0 mean no limit.
+    line_numbers = false, -- Whether line numbers should be shown alongside the context.
     patterns = { -- Match patterns for TS nodes. These get wrapped to match at word boundaries.
         -- For all filetypes
         -- Note that setting an entry here replaces all other patterns for this entry.
@@ -61,3 +62,6 @@ require'treesitter-context'.setup{
 
 Use the highlight group `TreesitterContext` to change the colors of the
 context. Per default it links to `NormalFloat`.
+
+Use the highlight group `TreesitterContextLineNumber` to change the colors of the
+context line numbers if `line_numbers` is set. Per default it links to `LineNr`.

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -411,7 +411,7 @@ function M.close()
 
   if gutter_winid ~= nil and api.nvim_win_is_valid(gutter_winid) then
     -- Can't close other windows when the command-line window is open
-    if api.nvim_call_function("getcmdwintype", {}) ~= "" then
+    if api.nvim_call_function('getcmdwintype', {}) ~= '' then
       return
     end
 
@@ -456,9 +456,9 @@ function M.open()
     table.insert(context_indents, indents)
 
     if config.line_numbers then
-      local linenumber_string = string.format("%d", range[1] + 1)
-      local padding_string = string.rep(" ", gutter_width - 1 - string.len(linenumber_string))
-      local gutter_string = padding_string .. linenumber_string .. " "
+      local linenumber_string = string.format('%d', range[1] + 1)
+      local padding_string = string.rep(' ', gutter_width - 1 - string.len(linenumber_string))
+      local gutter_string = padding_string .. linenumber_string .. ' '
       table.insert(context_linenumbers_text, gutter_string)
     end
   end
@@ -630,7 +630,7 @@ api.nvim_command('command! TSContextDisable lua require("treesitter-context").di
 api.nvim_command('command! TSContextToggle  lua require("treesitter-context").toggleEnabled()')
 
 api.nvim_command('highlight default link TreesitterContext NormalFloat')
-api.nvim_command "highlight default link TreesitterContextLineNumber LineNr"
+api.nvim_command('highlight default link TreesitterContextLineNumber LineNr')
 
 nvim_augroup('treesitter_context', {
   {'VimEnter', '*', 'lua require("treesitter-context").onVimEnter()'},


### PR DESCRIPTION
Closes #37 if merged.

This implements the showing of line numbers by adding a second floating window that gets drawn on top of the gutter. A new highlight group has been added so that this can be themed (for example to highlight the different line number) - by default it just links to `LineNr` so it looks like any other line number.

Example with `highlight TreesitterContextLineNumber guifg=#c3e88d`:
![image](https://user-images.githubusercontent.com/9727338/146926334-ddb4cf69-bcd9-4468-baf5-243ee6d732eb.png)
