### PR TITLE
Only open on windows that are taller than some minimum window height

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ require'treesitter-context'.setup{
     enable = true, -- Enable this plugin (Can be enabled/disabled later via commands)
     max_lines = 0, -- How many lines the window should span. Values <= 0 mean no limit.
     trim_scope = 'outer', -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
+    min_window_height = 0, -- Minimum editor window height to enable context. Values <= 0 mean no limit.
     patterns = { -- Match patterns for TS nodes. These get wrapped to match at word boundaries.
         -- For all filetypes
         -- Note that setting an entry here replaces all other patterns for this entry.

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -13,6 +13,7 @@ end
 local defaultConfig = {
   enable = true,
   max_lines = 0, -- no limit
+  min_window_height = 0,
   line_numbers = true,
   multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line
   trim_scope = 'outer', -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
@@ -687,6 +688,11 @@ local update = throttle_fn(function()
     end
 
     previous_nodes = context
+
+    if api.nvim_win_get_height(0) < config.min_window_height then
+      M.close()
+      return
+    end
 
     open(context)
   else


### PR DESCRIPTION
This is helpful if you have an editor with a bunch of tiny windows to not have them eaten up by context that there's not space for.