### PR TITLE
feat: add config.multiline_threshold

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -13,6 +13,7 @@ end
 local defaultConfig = {
   enable = true,
   max_lines = 0, -- no limit
+  multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line
   zindex = 20,
 }
 
@@ -201,7 +202,7 @@ local function get_text_for_node(node)
     end
   end
 
-  if not last_position then
+  if not last_position or #lines > config.multiline_threshold then
     lines = vim.list_slice(lines, 1, 1)
     end_row = start_row
     end_col = #lines[1]


### PR DESCRIPTION
When creating a single context from multiple lines, if the amount of
lines reaches a specified threshold, then just use the first line.

The motivating use case is when passing in a large table to a function
in Lua, e.g. `packer.setup`.

Fixes #116
