### PR TITLE
feat: add config.mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ require'treesitter-context'.setup{
     --     you can safely ignore them.
 
     zindex = 20, -- The Z-index of the context window
+    mode = 'cursor',  -- Line used to calculate context. Choices: 'cursor', 'topline'
 }
 ```
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -14,6 +14,7 @@ local defaultConfig = {
   enable = true,
   max_lines = 0, -- no limit
   zindex = 20,
+  mode = 'cursor', -- Choices: 'cursor', 'topline'
 }
 
 local config = {}
@@ -329,7 +330,12 @@ local function get_parent_matches(max_lines)
     return
   end
 
-  local lnum, col = unpack(api.nvim_win_get_cursor(0))
+  local lnum, col
+  if config.mode == 'topline' then
+    lnum, col = vim.fn.line('w0'), 0
+  else -- default to 'cursor'
+    lnum, col = unpack(api.nvim_win_get_cursor(0))
+  end
 
   local node = get_root_node():named_descendant_for_range(lnum-1, col, lnum-1, col)
   if not node then


### PR DESCRIPTION
Choices:
    - 'cursor' (default): current behaviour, context is determined by
      cursor position
    - 'topline': context is determined by the top of the window

Resolves #77
