### PR TITLE
feat: show trailing return types

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -29,6 +29,7 @@ local last_named_fields = {
     c = { 'declarator' },
     cpp = { 'declarator' },
     lua = { 'parameters' },
+    teal = { 'signature' },
     python = { 'return_type', 'parameters' },
     rust = { 'return_type', 'parameters' },
     javascript =  { 'parameters' },


### PR DESCRIPTION
This shows trailing return types in rust, python, and typescript by querying named fields of the function nodes. I don't know if this is the preferred way to implement this or if one would use queries (I have never touched that), but it seems to work quite well.