### PR TITLE
add object to scala

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -99,6 +99,9 @@ local DEFAULT_TYPE_PATTERNS = {
   rust = {
     'impl_item',
   },
+  scala = {
+    'object',
+  },
   vhdl = {
     'process_statement',
     'architecture_body',

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -100,7 +100,7 @@ local DEFAULT_TYPE_PATTERNS = {
     'impl_item',
   },
   scala = {
-    'object',
+    'object_definition',
   },
   vhdl = {
     'process_statement',


### PR DESCRIPTION
there are nodes like `object_definition` in the scala treesitter, because you can do things like

```scala
object Foo {
  def dank(): Unit = println("foodank")
}
Foo.dank()
```

where in other languages, like java, you would do

```java
class Foo {
  public static void dank() { System.out.println("foodank"); }
}
Foo.dank();