### PR TITLE
fix: covered context not showing in topline mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,18 @@ nvim-treesitter/parser/lua.so: nvim-treesitter $(NEOVIM)
 			   -c "TSInstallSync lua" \
 			   -c "q"
 
+nvim-treesitter/parser/rust.so: nvim-treesitter $(NEOVIM)
+	VIMRUNTIME=$(NEOVIM)/runtime $(NEOVIM)/build/bin/nvim \
+			   --headless \
+			   --clean \
+			   --cmd 'set rtp+=./nvim-treesitter' \
+			   -c "TSInstallSync rust" \
+			   -c "q"
+
 export VIMRUNTIME=$(PWD)/$(NEOVIM)/runtime
 
 .PHONY: test
-test: $(NEOVIM) nvim-treesitter nvim-treesitter/parser/lua.so
+test: $(NEOVIM) nvim-treesitter nvim-treesitter/parser/lua.so nvim-treesitter/parser/rust.so
 	$(NEOVIM)/.deps/usr/bin/busted \
 		-v \
 		--lazy \

--- a/test/nested_file.rs
+++ b/test/nested_file.rs
@@ -1,0 +1,17 @@
+impl Foo {
+
+    fn bar(&self) {
+        if condition {
+
+
+            for i in 0..100 {
+
+
+            }
+        }
+    }
+}
+
+struct Foo {
+
+}

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -88,4 +88,99 @@ describe('ts_context', function()
     ]]}
   end)
 
+  it('edit a file in topline mode', function()
+    exec_lua[[require'treesitter-context'.setup{
+      mode = 'topline',
+      max_lines = 2,
+    }]]
+    cmd('edit test/nested_file.rs')
+    feed'L'
+    feed'<C-e>'
+    -- screen:snapshot_util()
+    screen:expect{grid=[[
+      {1:impl}{2: Foo {                    }|
+          {4:fn} {5:bar}({7:&}{8:self}) {           |
+              {4:if} condition {        |
+                                    |
+                                    |
+                  {4:for} i {4:in} {8:0}..{8:100} { |
+                                    |
+                                    |
+                  }                 |
+              }                     |
+          }                         |
+      }                             |
+                                    |
+      {4:^struct} {5:Foo} {                  |
+                                    |
+                                    |
+    ]], attr_ids={
+      [1] = {foreground = Screen.colors.Brown, background = Screen.colors.Plum1, bold = true};
+      [2] = {background = Screen.colors.Plum1};
+      [3] = {foreground = Screen.colors.Cyan4, background = Screen.colors.Plum1};
+      [4] = {bold = true, foreground = Screen.colors.Brown};
+      [5] = {foreground = Screen.colors.Cyan4};
+      [6] = {bold = true, foreground = Screen.colors.Blue1};
+      [7] = {bold = true, foreground = Screen.colors.SeaGreen4};
+      [8] = {foreground = Screen.colors.Fuchsia};
+    }}
+
+    feed'<C-e>'
+    screen:expect{grid=[[
+      {2:    }{1:fn}{2: }{3:bar}{2:(}{7:&}{8:self}{2:)             }|
+      {2:        }{1:if}{2: condition {        }|
+                                    |
+                                    |
+                  {4:for} i {4:in} {9:0}..{9:100} { |
+                                    |
+                                    |
+                  }                 |
+              }                     |
+          }                         |
+      }                             |
+                                    |
+      {4:^struct} {5:Foo} {                  |
+                                    |
+      }                             |
+                                    |
+    ]], attr_ids={
+      [1] = {foreground = Screen.colors.Brown, bold = true, background = Screen.colors.LightMagenta};
+      [2] = {background = Screen.colors.LightMagenta};
+      [3] = {background = Screen.colors.LightMagenta, foreground = Screen.colors.Cyan4};
+      [4] = {foreground = Screen.colors.Brown, bold = true};
+      [5] = {foreground = Screen.colors.Cyan4};
+      [6] = {foreground = Screen.colors.Blue1, bold = true};
+      [7] = {foreground = Screen.colors.SeaGreen4, bold = true, background = Screen.colors.LightMagenta};
+      [8] = {background = Screen.colors.LightMagenta, foreground = Screen.colors.Magenta1};
+      [9] = {foreground = Screen.colors.Magenta1};
+    }}
+
+    feed'3<C-e>'
+    screen:expect{grid=[[
+      {2:        }{1:if}{2: condition {        }|
+      {2:            }{1:for}{2: i }{1:in}{2: }{7:0}{2:..}{7:100}{2: { }|
+                                    |
+                                    |
+                  }                 |
+              }                     |
+          }                         |
+      }                             |
+                                    |
+      {4:^struct} {5:Foo} {                  |
+                                    |
+      }                             |
+      {6:~                             }|
+      {6:~                             }|
+      {6:~                             }|
+                                    |
+    ]], attr_ids={
+      [1] = {background = Screen.colors.Plum1, bold = true, foreground = Screen.colors.Brown};
+      [2] = {background = Screen.colors.Plum1};
+      [3] = {background = Screen.colors.Plum1, foreground = Screen.colors.Cyan4};
+      [4] = {foreground = Screen.colors.Brown, bold = true};
+      [5] = {foreground = Screen.colors.Cyan4};
+      [6] = {foreground = Screen.colors.Blue1, bold = true};
+      [7] = {background = Screen.colors.Plum1, foreground = Screen.colors.Magenta};
+    }}
+  end)
 end)


### PR DESCRIPTION
This fixes an issue in `topline` mode where sometimes context nodes don't get shown if they are covered by the popup. Essentially the `lnum` is incremented each time the window is known to be higher and the logic to collect parents is rerun.

This is probably the bug @rockyzhang24 mentioned in #128, which I failed to understand.

Before:
[![asciicast](https://asciinema.org/a/hCLS1zqEeqQL73MAv6ciMwHgx.svg)](https://asciinema.org/a/hCLS1zqEeqQL73MAv6ciMwHgx)

After:
[![asciicast](https://asciinema.org/a/Am906dIRB3UAloZCEypeX7XAm.svg)](https://asciinema.org/a/Am906dIRB3UAloZCEypeX7XAm)

The for loops and the `if let Some(stco) ...` line aren't shown as soon as they are covered by the popup before.