### PR TITLE
fix: set option nowrap on context window

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -333,8 +333,9 @@ local function display_window(bufnr, winid, width, height, col, ty, hl)
       border = sep and {'', '', '', '', sep, sep, sep, ''} or nil,
     })
     api.nvim_win_set_var(winid, ty, true)
-    vim.wo[winid].winhl = 'NormalFloat:'..hl
-    vim.wo[winid].foldenable = false
+    api.nvim_win_set_option(winid, 'wrap', false)
+    api.nvim_win_set_option(winid, 'foldenable', false)
+    api.nvim_win_set_option(winid, 'winhl', 'NormalFloat:' .. hl)
   else
     api.nvim_win_set_config(winid, {
       win = api.nvim_get_current_win(),


### PR DESCRIPTION
Closes #138 

Explicitly set the `nowrap` option on the context window.