### PR TITLE
Add struct and enum patterns to rust defaults

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -99,6 +99,8 @@ local DEFAULT_TYPE_PATTERNS = {
   },
   rust = {
     'impl_item',
+    'struct',
+    'enum',
   },
   scala = {
     'object_definition',


### PR DESCRIPTION
Self-explanatory. I feel like these two can be considered as sane default options.