### PR TITLE
feat: add markdown pattern

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -110,6 +110,9 @@ local DEFAULT_TYPE_PATTERNS = {
     'architecture_body',
     'entity_declaration',
   },
+  markdown = {
+    'section',
+  },
   exact_patterns = {},
 }
 


### PR DESCRIPTION
This adds a pattern to show the current section in the markdown file. It works with headings and subheadings also. This uses the new markdown parser that was recently added to nvim-treesitter.