### PR TITLE
Expose context positions

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -746,9 +746,10 @@ function M.setup(options)
   end
 end
 
+-- Get the window & buffer IDs for this context
 -- `winid` is not relevant at the moment, but it might be required if
--- we support more than 1 context window instance
--- @param winid number The window id to the the context refs for
+-- we support more than 1 context window instance eventually
+-- @param winid number The window id the context refs are for
 -- @returns table
 function M.get_context(winid)
   return {
@@ -761,7 +762,7 @@ end
 
 -- Map a context window position to the corresponding buffer position
 -- Same note as above for `winid`
--- @param winid number The window id to the the context refs for
+-- @param winid number The window id the context refs are for
 -- @param row number Zero-indexed row number
 -- @param col number Zero-indexed col number
 -- @returns table or nil


### PR DESCRIPTION
This PR exposes the required API to implement https://github.com/ggandor/leap.nvim/issues/29

We don't have a documented public API, but the 2 functions added here can be considered stable.

```
-- Get the window & buffer IDs for this context
-- `winid` is not relevant at the moment, but it might be required if
-- we support more than 1 context window instance eventually
-- @param winid number The window id the context refs are for
-- @returns table
function M.get_context(winid)
```
Example:
```lua
require'treesitter-context'.get_context(vim.api.nvim_get_current_win())
-- result
{                                                                                                                                                                                                                    
  context_bufnr = 16,                                                                                                                                                                                                
  context_winid = 1079,                                                                                                                                                                                              
  gutter_bufnr = 17,                                                                                                                                                                                                 
  gutter_winid = 1078                                                                                                                                                                                                
}
```
```
-- Map a context window position to the corresponding buffer position
-- Same note as above for `winid`
-- @param winid number The window id the context refs are for
-- @param row number Zero-indexed row number
-- @param col number Zero-indexed col number
-- @returns table or nil
function M.context_position_to_buffer_position(windid, row, col)
```
Example:
```lua
require'treesitter-context'.context_position_to_buffer_position(vim.api.nvim_get_current_win(), 0, 9)
-- result
{14, 4}
```

cc @ggandor