### PR TITLE
add config.separator to README default config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ require'treesitter-context'.setup{
 
     zindex = 20, -- The Z-index of the context window
     mode = 'cursor',  -- Line used to calculate context. Choices: 'cursor', 'topline'
+    separator = nil, -- Separator between context and content. Should be a single character string, like '-'.
 }
 ```
 


### PR DESCRIPTION
only discovered the `separator` configuration because i searched this repo for "border" and found issues about it (#55 + #119), so i figured a README update was in order.