### PR TITLE
fix: don't let separator cover the line when cursor at top

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ require'treesitter-context'.setup{
 
     zindex = 20, -- The Z-index of the context window
     mode = 'cursor',  -- Line used to calculate context. Choices: 'cursor', 'topline'
-    separator = nil, -- Separator between context and content. Should be a single character string, like '-'.
+    -- Separator between context and content. Should be a single character string, like '-'.
+    -- When separator is set, the context will only show up when there are at least 2 lines above cursorline.
+    separator = nil,
 }
 ```
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -642,6 +642,11 @@ local function calc_max_lines(config_max)
   local wintop = vim.fn.line('w0')
   local cursor = vim.fn.line('.')
   local max_from_cursor = cursor - wintop
+
+  if config.separator and max_from_cursor > 0 then
+    max_from_cursor = max_from_cursor - 1 -- separator takes 1 line
+  end
+
   if max_lines ~= -1 then
     max_lines = math.min(max_lines, max_from_cursor)
   else


### PR DESCRIPTION
Fixes [#122](https://github.com/nvim-treesitter/nvim-treesitter-context/issues/122)