### PR TITLE
Add terraform default type patterns

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -104,6 +104,8 @@ local DEFAULT_TYPE_PATTERNS = {
   },
   terraform = {
     'block',
+    'object_elem',
+    'attribute',
   },
   scala = {
     'object_definition',

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -102,6 +102,9 @@ local DEFAULT_TYPE_PATTERNS = {
     'struct',
     'enum',
   },
+  terraform = {
+    'block',
+  },
   scala = {
     'object_definition',
   },


### PR DESCRIPTION
Terraform uses `block`s for all their top level data structures. Ideally I'd add a query for those that have an identifier that starts with `resource`, `data`, `locals` or `provider`. But that doesn't seem possible within this plugin.