### PR TITLE
add elixir default type patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ require'treesitter-context'.setup{
         markdown = {
             'section',
         },
+        elixir = {
+            'anonymous_function',
+            'arguments',
+            'block',
+            'do_block',
+            'list',
+            'map',
+            'tuple',
+            'quoted_content',
+        },
     },
     exact_patterns = {
         -- Example for a specific filetype with Lua patterns

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -113,6 +113,15 @@ local DEFAULT_TYPE_PATTERNS = {
   markdown = {
     'section',
   },
+  elixir = {
+    'anonymous_function',
+    'arguments',
+    'block',
+    'do_block',
+    'list',
+    'map',
+    'tuple',
+  },
   exact_patterns = {},
 }
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -121,6 +121,7 @@ local DEFAULT_TYPE_PATTERNS = {
     'list',
     'map',
     'tuple',
+    'quoted_content',
   },
   exact_patterns = {},
 }


### PR DESCRIPTION
Elixir has patterns that aren't picked up with the current default config. Adding the list defined in https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/elixir/folds.scm works pretty well with codebases I've been using it with.

### Before
Nothing happens. No treesitter context output shown.

https://user-images.githubusercontent.com/27223/188254512-f65a43ff-3743-4a79-a858-75a2ac2fbc4e.mov

### After
treesitter context works as expected with elixir source code


https://user-images.githubusercontent.com/27223/188254520-924f3cd8-9cd5-4d9f-ad42-d9ab890ea74a.mov

