### PR TITLE
Support YAML and JSON by defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ require'treesitter-context'.setup{
             'tuple',
             'quoted_content',
         },
+        json = {
+            'pair',
+        },
+        yaml = {
+            'block_mapping_pair',
+        },
     },
     exact_patterns = {
         -- Example for a specific filetype with Lua patterns

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -123,6 +123,12 @@ local DEFAULT_TYPE_PATTERNS = {
     'tuple',
     'quoted_content',
   },
+  json = {
+    'pair',
+  },
+  yaml = {
+    'block_mapping_pair',
+  },
   exact_patterns = {},
 }
 


### PR DESCRIPTION
This PR makes it possible to display keys of YAML and JSON.


| yaml | json |
|-|-|
| ![Screenshot_20220904_163706](https://user-images.githubusercontent.com/10358398/188303404-1f2af376-a6dc-4076-ba0b-b1b67d56bcf4.jpg) | ![Screenshot_20220904_164001](https://user-images.githubusercontent.com/10358398/188303407-7bcc257d-863f-45a1-a72b-c32316897c19.jpg) | 
