### PR TITLE
🔧 [default]: Add `interface` to default patterns

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -90,6 +90,7 @@ local DEFAULT_TYPE_PATTERNS = {
     'if',
     'switch',
     'case',
+    'interface',
   },
   tex = {
     'chapter',


### PR DESCRIPTION
I think `interface`, in addition to `class` makes sense for default groups that apply to many programming languages