### PR TITLE
Show haskell types as context

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -98,6 +98,9 @@ local DEFAULT_TYPE_PATTERNS = {
     'subsection',
     'subsubsection',
   },
+  haskell = {
+    'adt'
+  },
   rust = {
     'impl_item',
     'struct',


### PR DESCRIPTION
The haskell syntax tree has `adt` at the top of `data Blah where` declarations.

Sample of this working:
![image](https://user-images.githubusercontent.com/6652840/190927477-11407cef-60e5-4597-be0f-224e8d9937a9.png)
