### PR TITLE
feat: always show line numbers regardless of vimrc setting

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -15,6 +15,7 @@ local defaultConfig = {
   max_lines = 0, -- no limit
   min_window_height = 0,
   line_numbers = true,
+  always_show_line_numbers = nil, -- Always show line number regardless of vimrc settings. Choices: nil, 'relative', 'absolute'
   multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line
   trim_scope = 'outer', -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
   zindex = 20,
@@ -617,7 +618,7 @@ local function open(ctx_nodes)
 
   local gbufnr, ctx_bufnr = get_bufs()
 
-  if config.line_numbers and (vim.wo.number or vim.wo.relativenumber) then
+  if config.always_show_line_numbers or (config.line_numbers and (vim.wo.number or vim.wo.relativenumber)) then
     gutter_winid = display_window(
       gbufnr, gutter_winid, gutter_width, win_height, 0,
       'treesitter_context_line_number', 'TreesitterContextLineNumber')
@@ -649,7 +650,7 @@ local function open(ctx_nodes)
 
     local line_num
     local ctx_line_num = range[1] + 1
-    if vim.o.relativenumber then
+    if config.always_show_line_numbers == 'relative' or vim.o.relativenumber then
       line_num = get_relative_line_num(ctx_line_num)
     else
       line_num = ctx_line_num


### PR DESCRIPTION
I do not enable line number but do find relative/absolute line number useful in this case.

So i added another option to enable only for the context line.

![image](https://user-images.githubusercontent.com/21372855/192415292-0635b9da-93d1-4100-a259-162f81fef9fe.png)
![image](https://user-images.githubusercontent.com/21372855/192415379-6de44029-fc0f-49a8-9e6c-6475cbfd8fd5.png)
