### PR TITLE
feat: dynamically throttle context calculation

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -479,19 +479,16 @@ local function throttle_fn(fn)
       local start = vim.loop.hrtime()
       fn()
       local elapsed_ms = math.floor((vim.loop.hrtime() - start) / 1e6)
-      -- If this took < 5ms, we don't need a cooldown period. This prevents the context floats from flickering
-      if elapsed_ms > 5 then
+      -- If this took < 2ms, we don't need a cooldown period. This prevents the context floats from flickering
+      if elapsed_ms > 2 then
         cooling_down = true
-        -- Cool down for twice as long as we blocked the UI for.
-        -- This should mitigate some of the stuttering during scrolling.
-        local cooldown_period = 2 * elapsed_ms
         vim.defer_fn(function()
           cooling_down = false
           if recalc_after_cooldown then
             recalc_after_cooldown = false
             wrapped()
           end
-        end, cooldown_period)
+        end, 20)
       end
     end
   end


### PR DESCRIPTION
The existing throttling logic has a very significant downside: it adds a 50ms delay before updating the context floats. For some reason that little artifact bugged me enough to want to replace it, so here's my solution:

- On first call, run the recalculation with no delay.
- If the recalculation takes _more than 5ms_, put a lock in place for twice as long as the recalculation function blocked the main thread.
- If called again while locked, mark it as dirty (needing recalculation), and pass
- After the lock is released, run the recalculation if the dirty bit is set

This has the advantage of responding in realtime for most situations (smallish files), and dynamically adapting the throttling when the need arises (on larger files).

For comparison, I ran this test with the new throttle logic (left), current logic (center), and no throttling (right). The test was performed in tmux with the panes synchronized. The file is 168000 lines of ruby to accentuate scroll lag in the worst case.

https://user-images.githubusercontent.com/506791/195472850-f5b5fe60-2387-41d9-9e70-ac8996482719.mp4

To my eye, the new logic appears to perform as well as or better than the existing logic.

And then to compare the latency of the approaches, here is a test that highlights how long it takes for the context float to appear:

https://user-images.githubusercontent.com/506791/195472861-949d2a6c-9933-4966-ab93-9ad2b1c8adea.mp4

The new logic is much snappier
