### PR TITLE
hook: condition added nvim-treesitter/nvim-treesitter-context#172

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,20 @@ require'treesitter-context'.setup{
     -- Separator between context and content. Should be a single character string, like '-'.
     -- When separator is set, the context will only show up when there are at least 2 lines above cursorline.
     separator = nil,
+    -- A pre-hook that allow to disable treesitter-context based on buffer options
+    -- Here is a example where treesitter-context is disable for json and python files
+    -- Other custom logic can be assigned here related to buffer
+    -- If condition is true then treesitter-context will disable
+    condition = function(buf)
+      local ft = vim.fn.getbufvar(buf, "&filetype")
+      local disable_for = { "json", "python" }
+
+      if vim.tbl_contains(disable_for, ft) then
+        return true
+      end
+
+      return false
+    end,
 }
 ```
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -721,6 +721,12 @@ local update = throttle_fn(function()
     return
   end
 
+  -- condition (pre-hook) check
+  local buf = vim.api.nvim_get_current_buf()
+  if config.condition ~= nil and type(config.condition) == "function" and config.condition(buf) == true then
+    return
+  end
+
   local context = get_parent_matches(calc_max_lines(config.max_lines))
 
   if context and #context ~= 0 then


### PR DESCRIPTION
A pre-hook that allow to disable treesitter-context based on buffer. Here is a example where treesitter-context is disable for json and python files Other custom logic can be assigned here related to buffer. If condition is true then treesitter-context will disable.
```lua
require("treesitter-context").setup({
  condition = function(buf)
    local ft = vim.fn.getbufvar(buf, "&filetype")
    local disable_for = { "json", "python" }

    if vim.tbl_contains(disable_for, ft) then
      return true
    end

    return false
  end,
})
```