### PR TITLE
fix: skip leading types before highlighting contexts

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -231,17 +231,6 @@ local function get_text_for_node(node)
   local type = get_type_pattern(node, config.patterns.default) or node:type()
   local filetype = vim.bo.filetype
 
-  local skip_leading_type = (skip_leading_types[type] or {})[filetype]
-  if skip_leading_type then
-    local children = ts_utils.get_named_children(node)
-    for _, child in ipairs(children) do
-      if child:type() ~= skip_leading_type then
-        node = child
-        break
-      end
-    end
-  end
-
   local start_row, start_col = node:start()
   local end_row, end_col     = node:end_()
 
@@ -635,6 +624,24 @@ local function horizontal_scroll_contexts()
   end
 end
 
+local function normalize_node(node)
+  local type = get_type_pattern(node, config.patterns.default) or node:type()
+  local filetype = vim.bo.filetype
+
+  local skip_leading_type = (skip_leading_types[type] or {})[filetype]
+  if skip_leading_type then
+    local children = ts_utils.get_named_children(node)
+    for _, child in ipairs(children) do
+      if child:type() ~= skip_leading_type then
+        node = child
+        break
+      end
+    end
+  end
+
+  return node
+end
+
 local function open(ctx_nodes)
   local bufnr = api.nvim_get_current_buf()
 
@@ -661,6 +668,8 @@ local function open(ctx_nodes)
   local contexts = {}
 
   for _, node in ipairs(ctx_nodes) do
+    node = normalize_node(node)
+
     local lines, range = get_text_for_node(node)
     if lines == nil or range == nil or range[1] == nil then return end
     local text = merge_lines(lines)


### PR DESCRIPTION
When I'm trying to open a php file which contains an `#[Attribute]` before either `class_declaration` or `method_declaration` I getting following error:
```
Error detected while processing BufEnter Autocommands for "*":
Error executing lua callback: ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:590: attempt to perform arithmetic on a nil value
stack traceback:
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:590: in function 'highlight_contexts'
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:694: in function 'open'
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:738: in function 'fn'
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:481: in function <...ugged/nvim-treesitter-context/lua/treesitter-context.lua:476>
```
Here is the file to reproduce the problem:
```php
<?php

namespace Acme;

class TestController
{
    #[AnyAttribute]
    public function __construct()
    {
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        //
        // cursor here
    }
}
```

same problem here #165