### PR TITLE
Highlight the bottom line of context e.g. to add a border

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,3 +131,10 @@ context. Per default it links to `NormalFloat`.
 
 Use the highlight group `TreesitterContextLineNumber` to change the colors of the
 context line numbers if `line_numbers` is set. Per default it links to `LineNr`.
+
+Use the highlight group `TreesitterContextBottom` to change the highlight of the
+last line of the context window. By default it links to `NONE`.
+However, you can use this to create a border by applying an underline highlight, e.g:
+```vim
+hi TreesitterContextBottom gui=underline guisp=Grey
+```

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -692,6 +692,9 @@ local function open(ctx_nodes)
 
 
   highlight_contexts(bufnr, ctx_bufnr, contexts)
+
+  api.nvim_buf_set_extmark(ctx_bufnr, ns, #lno_text-1, 0, {end_line=#lno_text, hl_group='TreesitterContextBottom', hl_eol=true})
+  api.nvim_buf_set_extmark(gbufnr, ns, #context_text-1, 0, {end_line=#context_text, hl_group='TreesitterContextBottom', hl_eol=true})
 end
 
 local function calc_max_lines(config_max)
@@ -826,8 +829,9 @@ command('TSContextEnable' , M.enable , {})
 command('TSContextDisable', M.disable, {})
 command('TSContextToggle' , M.toggle , {})
 
-api.nvim_set_hl(0, 'TreesitterContext'          , {link = 'NormalFloat', default = true})
-api.nvim_set_hl(0, 'TreesitterContextLineNumber', {link = 'LineNr'     , default = true})
+api.nvim_set_hl(0, 'TreesitterContext',           {link = 'NormalFloat', default = true})
+api.nvim_set_hl(0, 'TreesitterContextLineNumber', {link = 'LineNr',      default = true})
+api.nvim_set_hl(0, 'TreesitterContextBottom',     {link = 'NONE',        default = true})
 
 -- Setup with default options if user didn't call setup()
 autocmd_for_group('treesitter_context')('VimEnter', function()


### PR DESCRIPTION
Adds a highlight to the bottom line of the context.

By default it does nothing, but I've been doing `hi TreesitterContextBottom gui=underline guisp=Grey`
to add a grey underline to the bottom to look like a border.
It's not perfect (see how it overlaps with the `f` and `p`; I guess it depends on your font),
but it does make a nice-ish border and saves a line compared to using the `separator` option.

![Screenshot_2022-10-24_00-54-25](https://user-images.githubusercontent.com/1336117/197396220-671a2e62-0bcf-474c-8f15-50e5c40fac5f.png)
