### PR TITLE
fix: set nomodified on context buffers

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -531,6 +531,7 @@ local function set_lines(bufnr, lines)
 
   if redraw then
     api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    api.nvim_buf_set_option(bufnr, 'modified', false)
   end
 
   return redraw


### PR DESCRIPTION
I've been having issues when I try to exit vim. It doesn't let me `:qall` because I have hidden, modified buffers. I think we should always set nomodified on these buffers to prevent that issue.