### PR TITLE
🔧 [default]: Add `enum` and `struct`  to default patterns

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -93,6 +93,8 @@ local DEFAULT_TYPE_PATTERNS = {
     'switch',
     'case',
     'interface',
+    'struct',
+    'enum',
   },
   tex = {
     'chapter',
@@ -105,8 +107,7 @@ local DEFAULT_TYPE_PATTERNS = {
   },
   rust = {
     'impl_item',
-    'struct',
-    'enum',
+ 
   },
   terraform = {
     'block',


### PR DESCRIPTION
I think `enum` and `struct`, in addition to `class` makes sense for default groups that apply to many programming languages