### PR TITLE
fix: schedule buffer update

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -477,7 +477,7 @@ local function throttle_fn(fn)
       recalc_after_cooldown = true
     else
       local start = vim.loop.hrtime()
-      fn()
+      vim.schedule(fn)
       local elapsed_ms = math.floor((vim.loop.hrtime() - start) / 1e6)
       -- If this took < 2ms, we don't need a cooldown period. This prevents the context floats from flickering
       if elapsed_ms > 2 then


### PR DESCRIPTION
Any buffer update should only be executed when it is safe. Therefore, to avoid textlock or other temporary restriction, the function call should be scheduled in the main event-loop by using `vim.schedule()`

This fixes visual anomalies that occur when scrolling all the way to the end of a page when a context is open.