### PR TITLE
Update readme pattern defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ require'treesitter-context'.setup{
             'if',
             'switch',
             'case',
+            'interface',
+            'struct',
+            'enum',
         },
         -- Patterns for specific filetypes
         -- If a pattern is missing, *open a PR* so everyone can benefit.
@@ -68,10 +71,17 @@ require'treesitter-context'.setup{
             'subsection',
             'subsubsection',
         },
+        haskell = {
+            'adt'
+        },
         rust = {
             'impl_item',
-            'struct',
-            'enum',
+
+        },
+        terraform = {
+            'block',
+            'object_elem',
+            'attribute',
         },
         scala = {
             'object_definition',


### PR DESCRIPTION
Sync pattern defaults in readme.

Might be worth directly linking to the source in the readme to prevent duplication:
https://github.com/nvim-treesitter/nvim-treesitter-context/blob/c61464bafb13595a5927f60606f0440bd3d83336/lua/treesitter-context.lua#L86-L146