### PR TITLE
fix: close window in right way (#191)

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -748,7 +748,7 @@ local update = throttle_fn(function()
     previous_nodes = context
 
     if api.nvim_win_get_height(0) < config.min_window_height then
-      M.close()
+      close()
       return
     end
 


### PR DESCRIPTION
use `close()` function to close window instead of `M.close()`.