### PR TITLE
feat: support python's `with` statement

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -115,6 +115,9 @@ local DEFAULT_TYPE_PATTERNS = {
   markdown = {
     'section',
   },
+  python = {
+    'with_statement',
+  },
   rust = {
     'impl_item',
   },


### PR DESCRIPTION
Example:
```python
def example_func():
    file_name = "tmp/secrets.txt"
    with open(file_name, "rb+") as f:
      # ...
      # cursor here
```

Will show both the function definition and the `with` line as context.