### PR TITLE
Add ruby blocks to lists of patterns

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -118,6 +118,9 @@ local DEFAULT_TYPE_PATTERNS = {
   python = {
     'with_statement',
   },
+  ruby = {
+    'block',
+  },
   rust = {
     'impl_item',
   },


### PR DESCRIPTION
Some Ruby frameworks make heavy use of blocks (Rails, RSpec). This makes treesitter-context a lot more helpful in those frameworks.