### PR TITLE
Show virtual text in context bar

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -661,7 +661,6 @@ local virt_text_ns = api.nvim_create_namespace("nvim-treesitter-context-virt-tex
 local function render_virtual_text(cbufnr, extmarks, diagnostics)
   api.nvim_buf_clear_namespace(cbufnr, virt_text_ns, 0, -1)
   vim.diagnostic.reset(virt_text_ns, cbufnr)
-  vim.diagnostic.set(virt_text_ns, cbufnr, diagnostics, { signs = false })
 
   local len = api.nvim_buf_line_count(cbufnr)
   for line = 0, len do
@@ -669,6 +668,8 @@ local function render_virtual_text(cbufnr, extmarks, diagnostics)
       api.nvim_buf_set_extmark(cbufnr, virt_text_ns, line, m_info.col, m_info.opts)
     end
   end
+
+  vim.diagnostic.set(virt_text_ns, cbufnr, diagnostics, { signs = false })
 end
 
 ---Clone existing, namespaced, extmarks present in the given range, and insert them into extmarks
@@ -680,6 +681,7 @@ local function clone_extmarks_into(extmarks, bufnr, range, context_line_num)
   for _, n in pairs(api.nvim_get_namespaces()) do
     local found_extmarks = api.nvim_buf_get_extmarks(bufnr, n, { range[1], range[2] }, { range[3], range[4] },
       { details = true })
+    P(found_extmarks)
     for _, e in pairs(found_extmarks) do
       if extmarks[context_line_num] == nil then
         extmarks[context_line_num] = {}

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -653,40 +653,71 @@ local function normalize_node(node)
   return node
 end
 
-local virt_text_ns = api.nvim_create_namespace("treesitter-context-virt-text")
-local function render_virtual_text(bufnr, extmarks)
-  local len = api.nvim_buf_line_count(bufnr)
-  api.nvim_buf_clear_namespace(bufnr, virt_text_ns, 0, -1)
-  for line, marks in pairs(extmarks) do
-    if line <= len then
-      for _, mark in ipairs(marks) do
-        api.nvim_buf_set_extmark(bufnr, virt_text_ns, line, mark.col, mark.opts)
-      end
+local virt_text_ns = api.nvim_create_namespace("nvim-treesitter-context-virt-text")
+---Render virtual text in the context buffer, includes extmarks and diagnostics
+---@param cbufnr integer buf number of the context buffer
+---@param extmarks table result of `clone_extmarks_into()`
+---@param diagnostics table result of `clone_diagnostics_into()`
+local function render_virtual_text(cbufnr, extmarks, diagnostics)
+  api.nvim_buf_clear_namespace(cbufnr, virt_text_ns, 0, -1)
+  vim.diagnostic.reset(virt_text_ns, cbufnr)
+  vim.diagnostic.set(virt_text_ns, cbufnr, diagnostics, { signs = false })
+
+  local len = api.nvim_buf_line_count(cbufnr)
+  for line = 0, len do
+    for _, m_info in ipairs(extmarks[line] or {}) do
+      api.nvim_buf_set_extmark(cbufnr, virt_text_ns, line, m_info.col, m_info.opts)
     end
   end
-  return false
 end
 
----Clone all existing, namespaced extmarks present in the given range, and insert them into
----extmark_info
----@param extmark_info table from line number to list of extmarks on that line
+---Clone existing, namespaced, extmarks present in the given range, and insert them into extmarks
+---@param extmarks table from line number to list of extmarks on that line
 ---@param bufnr integer buffer number we're searching for ext marks
 ---@param range table<integer> { start_row, start_col, end_row, end_col }
 ---@param context_line_num integer the line in the context that this should be associated with
-local function clone_ext_marks_into(extmark_info, bufnr, range, context_line_num)
+local function clone_extmarks_into(extmarks, bufnr, range, context_line_num)
   for _, n in pairs(api.nvim_get_namespaces()) do
-    local extmarks = api.nvim_buf_get_extmarks(bufnr, n, { range[1], range[2] }, { range[3], range[4] },
+    local found_extmarks = api.nvim_buf_get_extmarks(bufnr, n, { range[1], range[2] }, { range[3], range[4] },
       { details = true })
-    for _, e in pairs(extmarks) do
-      if extmark_info[context_line_num] == nil then
-        extmark_info[context_line_num] = {}
+    for _, e in pairs(found_extmarks) do
+      if extmarks[context_line_num] == nil then
+        extmarks[context_line_num] = {}
       end
-      table.insert(extmark_info[context_line_num], { col = e[3], opts = e[4] })
+      table.insert(extmarks[context_line_num], { col = e[3], opts = e[4] })
     end
   end
 end
 
-local function open(ctx_nodes)
+function table.deepcopy(orig)
+  local orig_type = type(orig)
+  local copy
+  if orig_type == 'table' then
+    copy = {}
+    for orig_key, orig_value in next, orig, nil do
+      copy[table.deepcopy(orig_key)] = table.deepcopy(orig_value)
+    end
+    setmetatable(copy, table.deepcopy(getmetatable(orig)))
+  else -- number, string, boolean, etc
+    copy = orig
+  end
+  return copy
+end
+
+---Clone existing diagnostic info from the given line
+---@param diagnostics table from line number to list of diagnostics on that line
+---@param bufnr integer buffer to find diagnostics in
+---@param line integer line to copy diagnostics from
+---@param context_line_num integer corresponding context buf line number
+local function clone_diagnostics_into(diagnostics, bufnr, line, context_line_num)
+  for _, d in ipairs(vim.diagnostic.get(bufnr, { lnum = line })) do
+    local copy = table.deepcopy(d)
+    copy.lnum = context_line_num
+    table.insert(diagnostics, copy)
+  end
+end
+
+local function open(ctx_nodes) 
   local bufnr = api.nvim_get_current_buf()
 
   local gutter_width = get_gutter_width()
@@ -711,6 +742,7 @@ local function open(ctx_nodes)
   local lno_text = {}
   local contexts = {}
   local extmarks = {}
+  local diagnostics = {}
 
   for idx, node in ipairs(ctx_nodes) do
     node = normalize_node(node)
@@ -736,13 +768,14 @@ local function open(ctx_nodes)
       line_num = ctx_line_num
     end
     table.insert(lno_text, build_lno_str(line_num, gutter_width-1))
-    clone_ext_marks_into(extmarks, bufnr, range, idx - 1)
+    clone_extmarks_into(extmarks, bufnr, range, idx - 1)
+    clone_diagnostics_into(diagnostics, bufnr, ctx_line_num - 1, idx - 1)
   end
 
   set_lines(gbufnr, lno_text)
   local skip_highlights = not set_lines(ctx_bufnr, context_text)
 
-  render_virtual_text(ctx_bufnr, extmarks)
+  render_virtual_text(ctx_bufnr, extmarks, diagnostics)
 
   if skip_highlights then
     return

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -690,6 +690,7 @@ local function clone_extmarks_into(extmarks, bufnr, range, context_line_num)
   end
 end
 
+-- http://lua-users.org/wiki/CopyTable
 function table.deepcopy(orig)
   local orig_type = type(orig)
   local copy

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -681,7 +681,6 @@ local function clone_extmarks_into(extmarks, bufnr, range, context_line_num)
   for _, n in pairs(api.nvim_get_namespaces()) do
     local found_extmarks = api.nvim_buf_get_extmarks(bufnr, n, { range[1], range[2] }, { range[3], range[4] },
       { details = true })
-    P(found_extmarks)
     for _, e in pairs(found_extmarks) do
       if extmarks[context_line_num] == nil then
         extmarks[context_line_num] = {}


### PR DESCRIPTION
Got bored and took a shot at #202 

This implementation has a few drawbacks: 
- Does not update until you scroll 
- Does not show all virtual text, only the stuff with namespaces
- Sometimes the ordering of the diagnostics and virtual text that shows at the end of a line flips
  - Virtual text should always render right at the end of the line, diagnostics render to the right of it. 

But neotest virtual text, and lsp diagnostics do show up now

<img width="774" alt="image" src="https://user-images.githubusercontent.com/56943754/216752491-ece768f9-29c2-4bbe-85cb-1e75efbce0cd.png">

Still not showing the sign column information, I don't plan on adding that