### PR TITLE
Show context for `table_constructor` in lua

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ require'treesitter-context'.setup{
         json = {
             'pair',
         },
+        lua = {
+            'table_constructor',
+        },
         typescript = {
             'export_statement',
         },

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -112,6 +112,9 @@ local DEFAULT_TYPE_PATTERNS = {
   json = {
     'pair',
   },
+  lua = {
+    'table_constructor',
+  },
   markdown = {
     'section',
   },


### PR DESCRIPTION
Within lua files such as neovim config files, I find many table constructors longer than the window size, where a context line would be helpful. For example:

<img width="486" alt="image" src="https://user-images.githubusercontent.com/7785912/223479082-38697678-84c8-42e4-94ca-d9376ae2bc11.png">

This PR adds a context line for lua table constructors by default.