### PR TITLE
Add terraform default type patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [x] `smali`
   - [x] `swift`
   - [x] `teal`
+  - [x] `terraform`
   - [x] `toml`
   - [x] `tsx`
   - [x] `typescript`
@@ -176,7 +177,6 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [ ] `svelte`
   - [ ] `sxhkdrc`
   - [ ] `t32`
-  - [ ] `terraform`
   - [ ] `thrift`
   - [ ] `tiger`
   - [ ] `tlaplus`

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -93,6 +93,8 @@ local is_valid = cache.memoize(function(node, query)
   range[3] = range[1]
   range[4] = -1
 
+  local node_srow = range[1]
+
   -- Try and iterate on the parent node as iter_matches won't match on the top
   -- level node
   local iter_node = node:parent() or node
@@ -104,13 +106,16 @@ local is_valid = cache.memoize(function(node, query)
       local srow, scol, erow, ecol = node0:range()
 
       -- because iter_node != node we could match outside of node
-      if srow < range[1] then
+      if srow < node_srow then
         break
       end
 
       local name = query.captures[id] -- name of the capture in the query
       if not r and name == 'context' then
         r = node == node0
+      elseif name == 'context.start' then
+        range[1] = srow
+        range[2] = scol
       elseif name == 'context.final' then
         range[3] = erow
         range[4] = ecol

--- a/queries/terraform/context.scm
+++ b/queries/terraform/context.scm
@@ -1,0 +1,9 @@
+
+([
+  (block)
+  (object)
+  (object_elem)
+  (attribute)
+  (template_literal)
+] @context)
+

--- a/queries/terraform/context.scm
+++ b/queries/terraform/context.scm
@@ -7,3 +7,9 @@
   (template_literal)
 ] @context)
 
+(for_object_expr
+  (_)
+  (for_intro) @context.start
+  (_) @context.end
+) @context
+

--- a/test/test.tf
+++ b/test/test.tf
@@ -1,0 +1,31 @@
+
+locals {
+  input_deps = {
+    for slug, group in local.t2r_map :
+    slug => {
+      a = 1
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+      a = 1
+      a = 1
+      a = 1
+    }
+  }
+}


### PR DESCRIPTION
Re adds the default patterns from https://github.com/nvim-treesitter/nvim-treesitter-context/pull/156.

Terraform uses `block`s for all their top level data structures. Ideally I'd add a query for those that have an identifier that starts with `resource`, `data`, `locals` or `provider`. But i need some advice on how to do this.
