### PR TITLE
add queries for go, javascript, extend toml queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [x] `cpp`
   - [x] `typescript`
   - [x] `rust`
+  - [X] `javascript`
   - [x] `json`
   - [x] `lua`
   - [x] `markdown`
@@ -109,7 +110,6 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [ ] `http`
   - [ ] `ini`
   - [ ] `java`
-  - [ ] `javascript`
   - [ ] `jq`
   - [ ] `jsdoc`
   - [ ] `json5`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [x] `cpp`
   - [x] `typescript`
   - [x] `rust`
+  - [X] `go`
   - [X] `javascript`
   - [x] `json`
   - [x] `lua`
@@ -91,7 +92,6 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [ ] `gleam`
   - [ ] `glimmer`
   - [ ] `glsl`
-  - [ ] `go`
   - [ ] `godot_resource`
   - [ ] `gomod`
   - [ ] `gosum`

--- a/queries/go/context.scm
+++ b/queries/go/context.scm
@@ -1,0 +1,9 @@
+([
+  (method_declaration)
+  (function_declaration)
+  (var_declaration)
+  (type_declaration)
+  (import_declaration)
+  (if_statement)
+  (const_declaration)
+] @context)

--- a/queries/javascript/context.scm
+++ b/queries/javascript/context.scm
@@ -1,0 +1,19 @@
+(if_statement
+  consequence: (_) @context.end
+) @context
+
+([
+  (class_declaration)
+  (function_declaration)
+  (lexical_declaration)
+  (method_definition)
+  (arrow_function)
+  (else_clause)
+  (while_statement)
+  (expression_statement)
+  (jsx_element)
+  (jsx_self_closing_element)
+  (call_expression)
+  (object)
+  (pair)
+] @context)

--- a/queries/toml/context.scm
+++ b/queries/toml/context.scm
@@ -1,5 +1,8 @@
 
 ([
   (table)
+  (table_array_element)
+  (inline_table)
+  (array)
   (pair)
 ] @context)


### PR DESCRIPTION
Thank you for merging this huge refactor :) I like using queries much more. 

I extended toml-queries as I think they are even better. 

Since go & javascript are languages I only sometimes _read_ code in, but don't write much, I added more simple queries, without looking more into multi-line-statements / `context.end` etc. I'm happy to remove the commits again if that's an issue, but I would guess that these simple queries are better than no queries :) 