### PR TITLE
add java queries

### DIFF
--- a/queries/java/context.scm
+++ b/queries/java/context.scm
@@ -18,6 +18,4 @@
   body: (_) @context.end
 ) @context
 
-([
-  (expression_statement)
-] @context)
+(expression_statement) @context

--- a/queries/java/context.scm
+++ b/queries/java/context.scm
@@ -1,0 +1,23 @@
+(if_statement
+  consequence: (_) @context.end
+) @context
+
+(method_declaration
+  body: (_) @context.end
+) @context
+
+(for_statement
+  body: (_) @context.end
+) @context
+
+(enhanced_for_statement
+  body: (_) @context.end
+) @context
+
+(class_declaration
+  body: (_) @context.end
+) @context
+
+([
+  (expression_statement)
+] @context)

--- a/test/test.java
+++ b/test/test.java
@@ -1,0 +1,44 @@
+package mymod;
+
+import stuff1;
+import stuff2;
+
+@class_annot_1
+@class_annot_2
+public class MyClass {
+
+
+
+
+    @method_annot_1
+    @method_annot_2
+    public void my_method(int param) {
+
+
+
+
+        if (true) {
+
+
+
+
+            for (int i = 0; i < 10; i++) {
+                
+
+
+
+                for (int var : iterable) {
+                    
+
+
+
+                    System.
+
+
+
+                        out.println("a message");
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Small PR to add Java queries.

The plugin seems to work in the actual editor, but when I tried to write test cases I couldn't get it to work for some reason. Inspecting it with the `screen:snapshot_util()` function would show up everything except the class declaration. Not sure what was going on there. Happy to include a test case if someone can advise.