### PR TITLE
remove `expression_statement` from python context

### DIFF
--- a/queries/python/context.scm
+++ b/queries/python/context.scm
@@ -43,5 +43,4 @@
   (finally_clause)
   (else_clause)
   (pair)
-  (expression_statement)
 ] @context)


### PR DESCRIPTION
having `expression_statement` here leads to the first line of the docstring being part of the context, see 
<img width="639" alt="grafik" src="https://user-images.githubusercontent.com/540890/226096088-3f1b3c28-8e0c-4543-ab0b-67d72ac83822.png">

which is not what I intended. 

I'll try some better definition, probably adding multi-line calls & assignments separately, but I would like to do this in a separate PR, after I tested some alternatives. 