### PR TITLE
feat(cpp): add linkage specification context

### DIFF
--- a/queries/cpp/context.scm
+++ b/queries/cpp/context.scm
@@ -3,3 +3,7 @@
 (class_specifier
   body: (_ (_) @context.end)
 ) @context
+
+(linkage_specification
+  body: (declaration_list (_) @context.end)
+) @context


### PR DESCRIPTION
Add context for linkage specification inside C++ code. For example, in

```c++
extern "C"
{
    // SOME CODE
}
```

the line `extern "C" {` would sticky at the top for a sufficiently large amount of code in the block.