### PR TITLE
Add cpp for range loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ export VIMRUNTIME=$(PWD)/$(NEOVIM)/runtime
 
 .PHONY: test
 test: $(NEOVIM) nvim-treesitter \
+	nvim-treesitter/parser/cpp.so \
 	nvim-treesitter/parser/lua.so \
 	nvim-treesitter/parser/rust.so \
 	nvim-treesitter/parser/typescript.so

--- a/queries/cpp/context.scm
+++ b/queries/cpp/context.scm
@@ -1,5 +1,9 @@
 ; inherits: c
 
+(for_range_loop
+  body: (_ (_) @context.end)
+) @context
+
 (class_specifier
   body: (_ (_) @context.end)
 ) @context

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -73,11 +73,14 @@ int main(int arg1,
 
 
   do {
+    int array[1];
+    for (auto value : array) {
 
 
 
 
 
-    // cursor position 5
+      // cursor position 5
+    }
   } while (1);
 }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,0 +1,83 @@
+struct Struct {
+    int *f1;
+    int *f2;
+
+
+
+    // cursor position 1
+};
+
+
+
+
+
+
+
+
+class Class {
+    int *f1;
+    int *f2;
+
+
+
+    // cursor position 2
+};
+
+
+
+
+
+
+
+
+typedef enum {
+  E1,
+  E2,
+  E3
+
+
+  // cursor position 3
+} myenum;
+
+
+
+
+
+
+
+
+
+
+int main(int arg1,
+         char **arg2,
+         char **arg3
+         )
+{
+  if (arg1 == 4
+      && arg2 == arg3) {
+    for (int i = 0; i < arg1; i++) {
+      while (1) {
+
+
+
+
+
+        // cursor position 4
+      }
+    }
+  }
+
+
+
+
+
+
+  do {
+
+
+
+
+
+    // cursor position 5
+  } while (1);
+}

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -296,17 +296,17 @@ describe('ts_context', function()
                                       |
       ]]}
 
-      feed'16<C-e>'
+      feed'18<C-e>'
       screen:expect{grid=[[
         {7:int}{2: main(}{7:int}{2: arg1, }{7:char}{2: **arg2}|
         {2:  }{1:do}{2: {                        }|
+        {2:    }{1:for}{2: (}{7:auto}{2: value : array) {}|
                                       |
                                       |
-                                      |
-        ^    {8:// cursor position 5}      |
+        ^      {8:// cursor position 5}    |
+            }                         |
           } {4:while} ({11:1});                |
         }                             |
-        {6:~                             }|
         {6:~                             }|
         {6:~                             }|
         {6:~                             }|

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -211,6 +211,112 @@ describe('ts_context', function()
       ]]}
     end)
 
+    it('cpp', function()
+      cmd('edit test/test.cpp')
+      feed'<C-e>'
+
+      screen:expect{grid=[[
+        {7:struct}{2: Struct {               }|
+            {9:int} *f2;                  |
+                                      |
+                                      |
+                                      |
+        ^    {8:// cursor position 1}      |
+        };                            |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+      ]]}
+
+      feed'16<C-e>'
+
+      screen:expect{grid=[[
+        {7:class}{2: Class {                 }|
+            {9:int} *f2;                  |
+                                      |
+                                      |
+                                      |
+        ^    {8:// cursor position 2}      |
+        };                            |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+      ]]}
+
+      feed'16<C-e>'
+
+      screen:expect{grid=[[
+        {7:typedef}{2: }{7:enum}{2: {                }|
+          E2,                         |
+          E3                          |
+                                      |
+                                      |
+        ^  {8:// cursor position 3}        |
+        } myenum;                     |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+      ]]}
+
+      feed'26<C-e>'
+      screen:expect{grid=[[
+        {7:int}{2: main(}{7:int}{2: arg1, }{7:char}{2: **arg2}|
+        {2:  }{1:if}{2: (arg1 == }{10:4}{2: && arg2 == arg}|
+        {2:    }{1:for}{2: (}{7:int}{2: i = }{10:0}{2:; i < arg1; }|
+        {2:      }{1:while}{2: (}{10:1}{2:) {             }|
+                                      |
+        ^        {8:// cursor position 4}  |
+              }                       |
+            }                         |
+          }                           |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+                                      |
+      ]]}
+
+      feed'16<C-e>'
+      screen:expect{grid=[[
+        {7:int}{2: main(}{7:int}{2: arg1, }{7:char}{2: **arg2}|
+        {2:  }{1:do}{2: {                        }|
+                                      |
+                                      |
+                                      |
+        ^    {8:// cursor position 5}      |
+          } {4:while} ({11:1});                |
+        }                             |
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+        {6:~                             }|
+                                      |
+      ]]}
+    end)
+
     it('typescript', function()
       cmd('edit test/test.ts')
       feed'<C-e>'


### PR DESCRIPTION
The main reason for the pull request is to add a query for the C++ range based for loop. While I was at it I also decided to add a test file for the C++ language. I have included the test cases that are specified for the C language. I did this because they are separate languages and I think we should check that the features work in both, not just check C and assume that they work for C++. That being said, this introduces duplication of test code, if a test is added the the C file, the C++ test file needs to be updated as well. 