### PR TITLE
feat(zig): multiline

### DIFF
--- a/queries/zig/context.scm
+++ b/queries/zig/context.scm
@@ -1,18 +1,32 @@
 ([
-  (LoopStatement)
-  (LoopExpr)
   (LoopTypeExpr)
-  (IfStatement)
   (IfTypeExpr)
   (TestDecl)
   (SwitchExpr)
-  (SwitchProng)
 ] @context)
 
 (Decl
   (FnProto  (_))
+  (Block (_) @context.end)
 ) @context
 
 (VarDecl
   (ErrorUnionExpr (_))
 ) @context
+
+(IfStatement
+  (BlockExpr (_) @context.end)
+) @context
+
+(LoopStatement
+  (_ (BlockExpr (_) @context.end))
+) @context
+
+(LoopExpr
+  (_ (Block (_) @context.end))
+) @context
+
+(SwitchProng
+  (AssignExpr) @context.end
+) @context
+

--- a/test/test.zig
+++ b/test/test.zig
@@ -1,15 +1,18 @@
 test "stuff" {
-    while (i < 3) {
+    while (i < 3 &&
+        j > 4) {
         i += 1;
 
 
-        if (i == 2) {
+        if (i == 2
+        && j == 3) {
             // stuff
 
 
 
 
-        } else if (i == 3) {
+        } else if (i == 3 &&
+            j == 4) {
             // stuff
 
 
@@ -48,19 +51,13 @@ test "stuff" {
 
     const items = [_]i32 { 4, 5, 3, 4, 0 };
 
-    for (items) |value| {
-
-
-
-
-
-
-        sum += value;
-    }
+    // counting for loop
+    for
 
 
     var sum: i32 = 0;
-    const result = for (items) |value| {
+    const result = for (
+    items) |value| {
         if (value != null) {
             sum += value.?;
         }
@@ -109,9 +106,23 @@ const Stuff = struct {
     d: i8,
 }
 
-fn bar(a: i8) {
+fn bar(a: i8,
+b: i8) {
+    switch (a) {
+        42,
+        1 => {
+
+        }
+    }
     const b = switch (a) {
-        101 => blk: {
+        42,
+        1 => {
+
+
+        },
+
+        101,
+        102=> blk: {
 
 
 
@@ -128,7 +139,9 @@ fn bar(a: i8) {
     };
 
 }
-fn foo(a: i8, b:i8) Stuff {
+fn foo(a: i8,
+
+b:i8) Stuff {
     var p = Stuff {
         a: 1,
 
@@ -146,22 +159,10 @@ fn foo(a: i8, b:i8) Stuff {
     };
 
     return Stuff {
-        a: a,
+        .a = a,
 
 
-
-
-        b: b,
-
-
-
-
-        c: 0,
-
-
-
-
-        d: 0,
+        .b = b,
 
 
     };


### PR DESCRIPTION
I could not find any example for LoopType- and IfTypeExpr, and i do not understand enough about treesitter to write them using the tree-sitter-zig code.
The TypeExpr would essentially just be

```
(LoopTypeExpr
  (_ (_TypeExpr (_) @context.end))
) @context
```

but i am not really sure if doing something like
```
(LoopTypeExpr
  (_ (_ (_) @context.end))
) @context
```

is a good idea.


### Zig definitions
LoopStatement (https://github.com/maxxnino/tree-sitter-zig/blob/0d08703e4c3f426ec61695d7617415fff97029bd/grammar.js#L266):
```javascript
LoopStatement: ($) =>
            seq(
                optional(keyword("inline", $)),
                choice($.ForStatement, $.WhileStatement)
            ),

ForStatement: ($) =>
	choice(
		seq($.ForPrefix, $.BlockExpr, optional($._ElseStatementTail)),
		seq($.ForPrefix, $.AssignExpr, choice(SEMICOLON, $._ElseStatementTail))
	),

WhileStatement: ($) =>
	choice(
		seq($.WhilePrefix, $.BlockExpr, optional($._ElseStatementTail)),
		seq(
			$.WhilePrefix,
			$.AssignExpr,
			choice(SEMICOLON, $._ElseStatementTail)
		)
	),
```

LoopTypeExpr (https://github.com/maxxnino/tree-sitter-zig/blob/0d08703e4c3f426ec61695d7617415fff97029bd/grammar.js#L474):
```javascript
LoopTypeExpr: ($) =>
            seq(
                optional(keyword("inline", $)),
                choice($.ForTypeExpr, $.WhileTypeExpr)
            ),

ForTypeExpr: ($) =>
	prec.right(seq($.ForPrefix, $._TypeExpr, optional($._ElseTypeExprTail))),

WhileTypeExpr: ($) =>
	prec.right(seq($.WhilePrefix, $._TypeExpr, optional($._ElseTypeExprTail))),
```