### PR TITLE
graphql support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [x] `elixir`
   - [x] `fish`
   - [x] `go`
+  - [x] `graphql`
   - [x] `ini`
   - [x] `java`
   - [x] `javascript`
@@ -109,7 +110,6 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [ ] `gomod`
   - [ ] `gosum`
   - [ ] `gowork`
-  - [ ] `graphql`
   - [ ] `hack`
   - [ ] `haskell`
   - [ ] `hcl`

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [x] `ocaml_interface`
   - [x] `ocaml`
   - [x] `php`
+  - [x] `prisma`
   - [x] `python`
   - [x] `r`
   - [x] `ruby`
@@ -146,7 +147,6 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [ ] `pioasm`
   - [ ] `po`
   - [ ] `poe_filter`
-  - [ ] `prisma`
   - [ ] `proto`
   - [ ] `prql`
   - [ ] `pug`

--- a/queries/graphql/context.scm
+++ b/queries/graphql/context.scm
@@ -1,0 +1,30 @@
+(interface_type_definition
+  (fields_definition (_) @context.end)
+) @context
+
+(object_type_definition
+  (fields_definition (_) @context.end)
+) @context
+
+(schema_definition
+  (_) @context.end
+) @context
+
+(input_object_type_definition
+  (input_fields_definition (_) @context.end)
+) @context
+
+(operation_definition
+  (selection_set (_) @context.end)
+) @context
+
+(inline_fragment
+  (selection_set (_) @context.end)
+) @context
+
+(selection
+  (field
+    (arguments)
+    (selection_set (_) @context.end)
+  )
+) @context

--- a/queries/prisma/context.scm
+++ b/queries/prisma/context.scm
@@ -1,0 +1,8 @@
+(_
+  (statement_block (_) @context.end)
+) @context
+
+(enum_declaration
+  (enum_block (_) @context.end)
+) @context
+

--- a/test/test.graphql
+++ b/test/test.graphql
@@ -1,0 +1,78 @@
+interface
+  Foo
+{
+  id: ID!
+  name: String
+
+
+}
+
+input
+  Stuff {
+  limit: Int
+  since_id: ID
+
+}
+
+type Bar
+  implements Foo {
+  age: Int
+
+}
+
+type Mutation {
+  addBar(name: String, age: int): Bar
+}
+
+query Stuff {
+  name
+  foo {
+    name
+  }
+}
+
+query GetSearchResults {
+  search(contains: "Shakespeare") {
+    __typename
+    # inline fragment
+    ... on Book {
+      title
+    }
+    ... on Author {
+      name
+
+    }
+  }
+}
+
+mutation
+  CreateBar {
+  addBar(name: "AAAA",
+    age: 42) {
+    name
+    foo {
+      age
+
+    }
+  }
+}
+
+type Root {
+  name: String
+
+
+}
+
+schema {
+  query: Root
+
+
+}
+
+
+
+
+
+
+
+

--- a/test/test.prisma
+++ b/test/test.prisma
@@ -1,0 +1,51 @@
+datasource db {
+  provider = "postgresql"
+  // foo
+
+
+
+  url      = env("DATABASE_URL")
+}
+
+generator
+client {
+  provider = "prisma-client-js"
+
+
+}
+
+enum
+Role {
+
+  USER
+
+  ADMIN
+}
+
+
+model
+User {
+
+
+
+  id    Int     @id @default(autoincrement())
+  email String  @unique
+
+
+
+  name  String?
+  posts Post[]
+
+
+
+}
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
not really sure if this is needed, but if 'foo' in 
```graphql
foo {
  foo1,
  foo2,
  foo3,
  ...
}
```
should also be highlighted 

```(arguments)``` would have to be removed from ```(selection( field```