### PR TITLE
feat(graphql): graphql support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [x] `elixir`
   - [x] `fish`
   - [x] `go`
+  - [x] `graphql`
   - [x] `ini`
   - [x] `java`
   - [x] `javascript`
@@ -109,7 +110,6 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [ ] `gomod`
   - [ ] `gosum`
   - [ ] `gowork`
-  - [ ] `graphql`
   - [ ] `hack`
   - [ ] `haskell`
   - [ ] `hcl`

--- a/queries/graphql/context.scm
+++ b/queries/graphql/context.scm
@@ -1,0 +1,30 @@
+(interface_type_definition
+  (fields_definition (_) @context.end)
+) @context
+
+(object_type_definition
+  (fields_definition (_) @context.end)
+) @context
+
+(schema_definition
+  (_) @context.end
+) @context
+
+(input_object_type_definition
+  (input_fields_definition (_) @context.end)
+) @context
+
+(operation_definition
+  (selection_set (_) @context.end)
+) @context
+
+(inline_fragment
+  (selection_set (_) @context.end)
+) @context
+
+(selection
+  (field
+    (arguments)
+    (selection_set (_) @context.end)
+  )
+) @context

--- a/test/test.graphql
+++ b/test/test.graphql
@@ -1,0 +1,79 @@
+interface
+  Foo
+{
+  id: ID!
+  name: String
+
+
+}
+
+input
+  Stuff {
+  limit: Int
+  since_id: ID
+
+}
+
+type Bar
+  implements Foo {
+  age: Int
+
+}
+
+type Mutation {
+  addBar(name: String, age: int): Bar
+}
+
+query Stuff {
+  name
+  foo {
+    name
+  }
+}
+
+query GetSearchResults {
+  search(contains: "Shakespeare") {
+    __typename
+    # inline fragment
+    ... on Book {
+      title
+    }
+    ... on Author {
+      name
+
+    }
+  }
+}
+
+mutation
+  CreateBar {
+  addBar(name: "AAAA",
+    age: 42) {
+    name
+    foo {
+      age
+
+    }
+  }
+}
+
+type Root {
+  name: String
+
+
+}
+
+schema {
+  query: Root
+
+
+}
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
not really sure if this is needed, but if 'foo' in 
```graphql
foo {
  foo1,
  foo2,
  foo3,
  ...
}
```
should also be highlighted 

```(arguments)``` would have to be removed from ```(selection( field```