### PR TITLE
Add USD language

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [x] `toml`
   - [x] `tsx`
   - [x] `typescript`
+  - [x] `usd`
   - [x] `verilog`
   - [x] `vim`
   - [x] `yaml`

--- a/queries/usd/context.scm
+++ b/queries/usd/context.scm
@@ -1,4 +1,5 @@
-(
- [
+([
   (prim_definition)
+  (variant_set_definition)
+  (variant)
 ] @context)

--- a/queries/usd/context.scm
+++ b/queries/usd/context.scm
@@ -1,0 +1,4 @@
+(
+ [
+  (prim_definition)
+] @context)

--- a/test/test.usd
+++ b/test/test.usd
@@ -1,0 +1,111 @@
+def Xform "thing"
+{
+
+
+
+
+
+
+
+    def "thing" {}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    def Scope "child"
+    {
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        variantSet "thing" = {
+            "stuff" {
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                def Scope "more_child_001"
+                {
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+                }
+            }
+
+
+
+
+
+
+
+
+        }
+
+
+
+
+
+
+
+    }
+
+
+
+
+
+
+
+
+}


### PR DESCRIPTION
Now that the USD scene description language [is supported in nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter/pull/4774), I'd like to add it here to nvim-treesitter-context, too.

## Demonstration
### Test File
https://github.com/nvim-treesitter/nvim-treesitter-context/assets/10103049/e1d0be80-ab0c-40ee-86fb-3640724053c6

### Nested File
https://github.com/nvim-treesitter/nvim-treesitter-context/assets/10103049/c7c0afc0-a740-46e7-a649-05406f0c21f2

I've been using my own context.scm for a while and it works pretty well. In nested files it's so helpful! Please let me know if you'd like any changes.