### PR TITLE
feat: add TreesitterContextSeparator highlight group

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,9 @@ context. Per default it links to `NormalFloat`.
 Use the highlight group `TreesitterContextLineNumber` to change the colors of the
 context line numbers if `line_numbers` is set. Per default it links to `LineNr`.
 
+Use the highlight group `TreesitterContextSeparator` to change the colors of the
+separator if `separator` is set. By default it links to `FloatBorder`.
+
 Use the highlight group `TreesitterContextBottom` to change the highlight of the
 last line of the context window. By default it links to `NONE`.
 However, you can use this to create a border by applying an underline highlight, e.g:

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -240,7 +240,7 @@ end
 --- @return integer
 local function display_window(bufnr, winid, width, height, col, ty, hl)
   if not winid or not api.nvim_win_is_valid(winid) then
-    local sep = config.separator
+    local sep = config.separator and { config.separator, "TreesitterContextSeparator" } or nil
     winid = api.nvim_open_win(bufnr, false, {
       relative = 'win',
       width = width,
@@ -859,6 +859,7 @@ command('TSContextToggle' , M.toggle , {})
 api.nvim_set_hl(0, 'TreesitterContext',           {link = 'NormalFloat', default = true})
 api.nvim_set_hl(0, 'TreesitterContextLineNumber', {link = 'LineNr',      default = true})
 api.nvim_set_hl(0, 'TreesitterContextBottom',     {link = 'NONE',        default = true})
+api.nvim_set_hl(0, 'TreesitterContextSeparator',  {link = 'FloatBorder', default = true})
 
 -- Setup with default options if user didn't call setup()
 autocmd_for_group('treesitter_context')('VimEnter', function()


### PR DESCRIPTION
This allows customization of the separator's color without having to change the more general `FloatBorder` group.