### PR TITLE
feat(go): support func literals

### DIFF
--- a/queries/go/context.scm
+++ b/queries/go/context.scm
@@ -12,6 +12,10 @@
   body: (block (_) @context.end)
 ) @context
 
+(func_literal
+  body: (block (_) @context.end)
+) @context
+
 (method_declaration
   body: (block (_) @context.end)
 ) @context

--- a/test/test.go
+++ b/test/test.go
@@ -92,12 +92,19 @@ func foo(a int,
 
 
 
+var _ = Describe("something", func() {
 
 
 
+  When("it works", func() {
 
 
 
+    It("works!", func() {
+      Expect(thing).To(Work())
 
 
 
+    })
+  })
+})


### PR DESCRIPTION
This adds support for Go function literals. These are particularly useful when using testing frameworks like [Ginkgo](https://onsi.github.io/ginkgo).