### PR TITLE
Add support for haskell

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [x] `glimmer`
   - [x] `go`
   - [x] `graphql`
+  - [x] `haskell`
   - [x] `html_tags`
   - [x] `ini`
   - [x] `java`
@@ -121,7 +122,6 @@ use 'nvim-treesitter/nvim-treesitter-context'
   - [ ] `gosum`
   - [ ] `gowork`
   - [ ] `hack`
-  - [ ] `haskell`
   - [ ] `hcl`
   - [ ] `heex`
   - [ ] `hjson`

--- a/queries/haskell/context.scm
+++ b/queries/haskell/context.scm
@@ -1,3 +1,5 @@
-(function
-  rhs: (_) @context.end
-) @context
+([
+  (alt)
+  (exp_case)
+  (function)
+] @context)

--- a/queries/haskell/context.scm
+++ b/queries/haskell/context.scm
@@ -1,0 +1,3 @@
+(function
+  rhs: (_) @context.end
+) @context

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,0 +1,68 @@
+action = undefined
+
+function arg1 arg2 =
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    case (arg1, arg2) of
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        (Just _, Just _) -> do
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+            undefined
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+        _ -> undefined

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,5 +1,3 @@
-action = undefined
-
 function arg1 arg2 =
 
 


### PR DESCRIPTION
Tested locally and it works great. Not sure if there should be more nodes that the `context` should capture but they can be added in the future in the PR.

The image shows that how it look when running in the Haskell test file:

![plugin working for haskell file](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/72729880/9c65e016-bf4a-44a0-9b7b-bdda8a2750d9)
