### PR TITLE
fix(matlab): nvim-treesitter changed its parser.

### DIFF
--- a/queries/matlab/context.scm
+++ b/queries/matlab/context.scm
@@ -14,29 +14,28 @@
   (block (_) @context.end)
 ) @context
 
-(elseif_statement
+(elseif_clause
   (block (_) @context.end)
 ) @context
 
-(else_statement
+(else_clause
   (block (_) @context.end)
 ) @context
 
 (switch_statement) @context
 
-(case_statement
+(case_clause
   (block (_) @context.end)
 ) @context
 
-(otherwise_statement
+(otherwise_clause
   (block (_) @context.end)
 ) @context
 
 (try_statement
-  (block (_) @context.end)
-) @context
-
-(catch_statement
-  (block (_) @context.end)
-) @context
-
+  "try"
+  (block (_) @context.end) @context
+  "end")
+(catch_clause
+  "catch"
+  (block (_) @context.end) @context)


### PR DESCRIPTION
https://github.com/nvim-treesitter/nvim-treesitter/pull/4944 just got accepted, so this adds the context.scm for that parser.