### PR TITLE
Fix scrolling error: `treesitter-context.lua:409: E565: Not allowed to change text or change window`

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -406,7 +406,9 @@ end
 
 local function win_close(winid)
   if winid ~= nil and api.nvim_win_is_valid(winid) then
-    api.nvim_win_close(winid, true)
+    pcall(function()
+      api.nvim_win_close(winid, true)
+    end)
   end
 end
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -406,9 +406,8 @@ end
 
 local function win_close(winid)
   if winid ~= nil and api.nvim_win_is_valid(winid) then
-    pcall(function()
-      api.nvim_win_close(winid, true)
-    end)
+    -- pcall prevents the error described in #306
+    pcall(api.nvim_win_close, winid, true)
   end
 end
 


### PR DESCRIPTION
This is not a good fix but it does work.

I don't have a public reproduction, but the general behavior is scrolling causes this error. This PR just silences all errors from the offending call.

```
Error executing vim.schedule lua callback: ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:409: Vim:Error executing lua callback: BufEnter Autocomma
nds for "*": Vim(append):Error executing lua callback: ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:409: E565: Not allowed to change text or change window                                                                                                                                                       
stack traceback:                                                                                                                                                
        [C]: in function 'nvim_win_close'                                                                                                                       
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:409: in function 'win_close'                                                                
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:420: in function 'close'                                                                    
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:734: in function 'f'                                                                        
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:398: in function <...ugged/nvim-treesitter-context/lua/treesitter-context.lua:392>          
        [C]: in function 'bufload'                                                                                                                              
        vim/_editor.lua: in function 'region'                                                                                                                   
        ...unwrapped-0.9.1/share/nvim/runtime/lua/vim/highlight.lua:35: in function 'range'                                                                     
        ...re/nvim/plugged/nvim-ts-rainbow/lua/rainbow/internal.lua:82: in function 'update_range'                                                              
        ...re/nvim/plugged/nvim-ts-rainbow/lua/rainbow/internal.lua:186: in function 'cb'                                                                       
        ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:736: in function '_do_callback'                                                             
        ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:176: in function 'invalidate'                                                               
        ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:877: in function '_on_detach'                                                               
        ...nwrapped-0.9.1/share/nvim/runtime/lua/vim/treesitter.lua:73: in function <...nwrapped-0.9.1/share/nvim/runtime/lua/vim/treesitter.lua:69>            
        [C]: in function 'nvim_win_close'                                                                                                                       
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:409: in function 'win_close'                                                                
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:420: in function 'close'                                                                    
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:760: in function <...ugged/nvim-treesitter-context/lua/treesitter-context.lua:730>          
stack traceback:                                                                                                                                                
        [C]: in function 'bufload'                                                                                                                              
        vim/_editor.lua: in function 'region'                                                                                                                   
        ...unwrapped-0.9.1/share/nvim/runtime/lua/vim/highlight.lua:35: in function 'range'                                                                     
        ...re/nvim/plugged/nvim-ts-rainbow/lua/rainbow/internal.lua:82: in function 'update_range'                                                              
        ...re/nvim/plugged/nvim-ts-rainbow/lua/rainbow/internal.lua:186: in function 'cb'                                                                       
        ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:736: in function '_do_callback'                                                             
        ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:176: in function 'invalidate'                                                               
        ...1/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:877: in function '_on_detach'                                                               
        ...nwrapped-0.9.1/share/nvim/runtime/lua/vim/treesitter.lua:73: in function <...nwrapped-0.9.1/share/nvim/runtime/lua/vim/treesitter.lua:69>            
        [C]: in function 'nvim_win_close'                                                                                                                       
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:409: in function 'win_close'                                                                
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:420: in function 'close'                                                                    
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:760: in function <...ugged/nvim-treesitter-context/lua/treesitter-context.lua:730>          
stack traceback:                                                                                                                                                
        [C]: in function 'nvim_win_close'                                                                                                                       
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:409: in function 'win_close'                                                                
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:420: in function 'close'                                                                    
        ...ugged/nvim-treesitter-context/lua/treesitter-context.lua:760: in function <...ugged/nvim-treesitter-context/lua/treesitter-context.lua:730>

```