### PR TITLE
Fix #306 again

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -406,8 +406,7 @@ end
 
 local function win_close(winid)
   if winid ~= nil and api.nvim_win_is_valid(winid) then
-    -- pcall prevents the error described in #306
-    pcall(api.nvim_win_close, winid, true)
+    vim.schedule(function() api.nvim_win_close(winid, true) end)
   end
 end
 


### PR DESCRIPTION
#306 created another bug where the relative numbering window was never closed.
I thought `vim.schedule` was not working, but now it seems to be, so I may have made a mistake when testing it previously or there's another edge case I'm not currently triggering.