### PR TITLE
feat: better multiline contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # nvim-treesitter-context
 
 Lightweight alternative to [context.vim](https://github.com/wellle/context.vim)
-implemented with [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter).
 
 ## Requirements
 
@@ -187,13 +186,15 @@ Note: if you need support for Neovim 0.6.x please use the tag `compat/0.6`.
 
 (Default values are shown below)
 
+Note: calling `setup()` is optional.
+
 ```lua
 require'treesitter-context'.setup{
   enable = true, -- Enable this plugin (Can be enabled/disabled later via commands)
   max_lines = 0, -- How many lines the window should span. Values <= 0 mean no limit.
   min_window_height = 0, -- Minimum editor window height to enable context. Values <= 0 mean no limit.
   line_numbers = true,
-  multiline_threshold = 20, -- Maximum number of lines to collapse for a single context line
+  multiline_threshold = 20, -- Maximum number of lines to show for a single context
   trim_scope = 'outer', -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
   mode = 'cursor',  -- Line used to calculate context. Choices: 'cursor', 'topline'
   -- Separator between context and content. Should be a single character string, like '-'.

--- a/lua/treesitter-context/cache.lua
+++ b/lua/treesitter-context/cache.lua
@@ -16,7 +16,7 @@ function M.memoize(fn, hash_fn)
     end
 
     local v = cache[key]
-    return v ~= vim.NIL and v or nil
+    return v ~= vim.NIL and vim.deepcopy(v) or nil
   end
 end
 

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -26,6 +26,7 @@ describe('ts_context', function()
       [10] = {foreground = Screen.colors.Fuchsia, background = Screen.colors.LightMagenta};
       [11] = {foreground = Screen.colors.Fuchsia};
       [12] = {foreground = tonumber('0x6a0dad'), background = Screen.colors.LightMagenta};
+      [13] = {foreground = Screen.colors.White, background = Screen.colors.Red};
     })
     cmd [[set runtimepath+=.,./nvim-treesitter]]
     cmd [[let $XDG_CACHE_HOME='scratch/cache']]
@@ -192,11 +193,11 @@ describe('ts_context', function()
 
       feed'40<C-e>'
       screen:expect{grid=[[
-        {7:int}{2: main(}{7:int}{2: arg1, }{7:char}{2: **arg2}|
-        {2:  }{1:if}{2: (arg1 == }{10:4}{2: && arg2 == arg}|
+        {7:int}{2: main(}{7:int}{2: arg1,            }|
+        {2:         }{7:char}{2: **arg2,         }|
+        {2:  }{1:if}{2: (arg1 == }{10:4}{2:               }|
+        {2:      && arg2 == arg3) }{13:{}{2:      }|
         {2:    }{1:for}{2: (}{7:int}{2: i = }{10:0}{2:; i < arg1; }|
-        {2:      }{1:while}{2: (}{10:1}{2:) {             }|
-              }                       |
         ^                              |
               {4:do} {                    |
                 {8:// comment}            |
@@ -278,11 +279,11 @@ describe('ts_context', function()
 
       feed'26<C-e>'
       screen:expect{grid=[[
-        {7:int}{2: main(}{7:int}{2: arg1, }{7:char}{2: **arg2}|
-        {2:  }{1:if}{2: (arg1 == }{10:4}{2: && arg2 == arg}|
+        {7:int}{2: main(}{7:int}{2: arg1,            }|
+        {2:  }{1:if}{2: (arg1 == }{10:4}{2:               }|
+        {2:      && arg2 == arg3) {      }|
         {2:    }{1:for}{2: (}{7:int}{2: i = }{10:0}{2:; i < arg1; }|
         {2:      }{1:while}{2: (}{10:1}{2:) {             }|
-                                      |
         ^        {8:// cursor position 4}  |
               }                       |
             }                         |
@@ -298,11 +299,11 @@ describe('ts_context', function()
 
       feed'18<C-e>'
       screen:expect{grid=[[
-        {7:int}{2: main(}{7:int}{2: arg1, }{7:char}{2: **arg2}|
+        {7:int}{2: main(}{7:int}{2: arg1,            }|
+        {2:         }{7:char}{2: **arg2,         }|
+        {2:         }{7:char}{2: **arg3          }|
         {2:  }{1:do}{2: {                        }|
         {2:    }{1:for}{2: (}{7:auto}{2: value : array) {}|
-                                      |
-                                      |
         ^      {8:// cursor position 5}    |
             }                         |
           } {4:while} ({11:1});                |


### PR DESCRIPTION
Instead of collapsing all the lines in a node, instead display the node
on multiple lines if it requires it.

This should significantly simplify the highlighting logic since we don't
need to keep track of how lines are joined.
