### PR TITLE
fix: TS Context Render on CMD Line Window

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -78,6 +78,10 @@ local function can_open(bufnr, winid)
     return false
   end
 
+  if vim.fn.getcmdtype() ~= '' then
+    return false
+  end
+
   if api.nvim_win_get_height(winid) < config.min_window_height then
     return false
   end


### PR DESCRIPTION
Issue:

- Currently there's a bug that the Treesitter Context is rendering in cmd  line window as well as still rendering (after closing cmd line window)

<img width="1508" alt="Screenshot 2023-09-06 at 11 13 39" src="https://github.com/nvim-treesitter/nvim-treesitter-context/assets/37890287/fff78ff1-0213-47de-8d9e-8c8da3acb8b0">
<img width="1508" alt="Screenshot 2023-09-06 at 11 13 47" src="https://github.com/nvim-treesitter/nvim-treesitter-context/assets/37890287/e6863b95-1398-4ece-86e6-9ebbbb12ab71">


Fix:
- Do not render TS Context if it's a a cmd line window

After fix:
<img width="1512" alt="Screenshot 2023-09-06 at 11 14 25" src="https://github.com/nvim-treesitter/nvim-treesitter-context/assets/37890287/5e432a79-2d9d-4191-9ee0-435e6e0e84d6">
