### PR TITLE
fix the terrible display when the number of lines of the context object is too large

### DIFF
--- a/lua/treesitter-context/config.lua
+++ b/lua/treesitter-context/config.lua
@@ -15,6 +15,7 @@
 local default_config = {
   enable = true,
   max_lines = 0, -- no limit
+  max_lines_for_a_context_object = 1,
   min_window_height = 0,
   line_numbers = true,
   multiline_threshold = 20, -- Maximum number of lines to show for a single context

--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -177,7 +177,12 @@ local function get_text_for_range(range)
     end_row = end_row - 1
   end
 
-  return { start_row, 0, end_row, -1 }, lines
+  ctx_len = config.max_lines_for_a_context_object
+  if ctx_len == nil or ctx_len == 0 then
+    return { start_row, 0, end_row, -1 }, lines
+  end
+  return { start_row, 0, math.min(start_row + ctx_len - 1, end_row), -1 },
+    table.move(lines, 1, math.min(ctx_len, end_row), 1, {})
 end
 
 local M = {}


### PR DESCRIPTION
When showing the context of function like this:
```
    def __init__(
        self,
        rcut: float,
        rcut_smth: float,
        sel: List[str],
        neuron: List[int] = [24, 48, 96],
        axis_neuron: int = 8,
        resnet_dt: bool = False,
        trainable: bool = True,
        seed: Optional[int] = None,
        type_one_side: bool = True,
        exclude_types: List[List[int]] = [],
        set_davg_zero: bool = False,
        activation_function: str = "tanh",
        precision: str = "default",
        uniform_seed: bool = False,
        multi_task: bool = False,
        spin: Optional[Spin] = None,
        **kwargs,
    ) -> None:
```

The function arguments will occupy my entire screen.
![image](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/47053538/e38f9043-2f45-4723-8a66-0637529a63e6)

Therefore I add a new argument called `max_lines_for_a_context_object`, which limits the number of lines of the context. Here is a image when `max_lines_for_a_context_object == 1`:

![image](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/47053538/c37986f5-65e6-4a5a-9016-34e72c199b39)
