### PR TITLE
Bump required Neovim version to 0.9.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Lightweight alternative to [context.vim](https://github.com/wellle/context.vim)
 
 ## Requirements
 
-Neovim >= v0.8.2
+Neovim >= v0.9.0
 
 Note: if you need support for Neovim 0.6.x please use the tag `compat/0.6`.
 


### PR DESCRIPTION
The `vim.treesitter.get_range()` function is used [here][1], but that function was only added in Neovim [0.9.0][2], in [this PR][3].

It was causing errors about a nil value being called whenever treesitter-context refreshed.

[1]: https://github.com/nvim-treesitter/nvim-treesitter-context/blob/9afe41b/lua/treesitter-context/render.lua#L143
[2]: https://github.com/neovim/neovim/releases/tag/v0.9.0
[3]: https://github.com/neovim/neovim/pull/22613