### PR TITLE
zig: Add missing @context.end to ErrorUnionExpr.

### DIFF
--- a/queries/zig/context.scm
+++ b/queries/zig/context.scm
@@ -11,7 +11,7 @@
 ) @context
 
 (VarDecl
-  (ErrorUnionExpr (_))
+  (ErrorUnionExpr (_)  @context.end)
 ) @context
 
 (IfStatement


### PR DESCRIPTION
This fixes showing way too much context for structs (and possibly unions and friends).

BEFORE: 
![image](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/5539930/d0444090-658a-40f8-86b7-b616b025ad0a)

AFTER:
![image](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/5539930/e82ecebb-720b-426e-a412-73f76f2c4aee)

Disclaimer: I have no experience with treesitter queries whatsoever. I just experimented and it happed to work out.