### PR TITLE
javascript: add switch/case to the context.

### DIFF
--- a/queries/javascript/context.scm
+++ b/queries/javascript/context.scm
@@ -18,4 +18,6 @@
   (object)
   (pair)
   (while_statement)
+  (switch_statement)
+  (switch_case)
 ] @context)


### PR DESCRIPTION
![screenshot](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/1651122/4894a604-e365-4bfe-bae6-a725595d3e74)

Add switch/case for javascript.

I have not figured out how to catch multiple cases that work on the same block yet, but this is better than nothing.

Multiple case that needs different query.

```
   case A:
   case B: {
   }
```