### PR TITLE
Added objdump context and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Note: if you need support for Neovim 0.6.x please use the tag `compat/0.6`.
   - [x] `nim`
   - [x] `nix`
   - [x] `norg`
+  - [x] `objdump'
   - [x] `ocaml_interface`
   - [x] `ocaml`
   - [x] `odin`

--- a/queries/objdump/context.scm
+++ b/queries/objdump/context.scm
@@ -1,0 +1,4 @@
+[
+  (disassembly_section_label)
+  (disassembly_section)
+] @context

--- a/test/test.objdump
+++ b/test/test.objdump
@@ -1,0 +1,21 @@
+0000000000000012 <engine::world::World::initialize()> (File Offset: 0x82):
+_ZN6engine5world5World10initializeEv():
+/home/selecaoone/repositories/jumpy/engine/src/lib/world.cpp:22
+  12:	55                                                    	push   rbp
+  13:	53                                                    	push   rbx
+  14:	48 83 ec 08                                           	sub    rsp,0x8
+_ZN9__gnu_cxx17__normal_iteratorIPSt10unique_ptrIN6engine7systems6SystemESt14default_deleteIS4_EESt6vectorIS7_SaIS7_EEEC4ERKS8_():
+/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/stl_iterator.h:807
+  18:	48 8b 5f 60                                           	mov    rbx,QWORD PTR [rdi+0x60]
+  1c:	48 8b 6f 68                                           	mov    rbp,QWORD PTR [rdi+0x68]
+_ZN6engine5world5World10initializeEv():
+/home/selecaoone/repositories/jumpy/engine/src/lib/world.cpp:23
+  20:	48 39 eb                                              	cmp    rbx,rbp
+  23:	74 12                                                 	je     37 <engine::world::World::initialize()+0x25> (File Offset: 0xa7)
+_ZNKSt15__uniq_ptr_implIN6engine7systems6SystemESt14default_deleteIS2_EE6_M_ptrEv():
+/opt/rh/devtoolset-9/root/usr/include/c++/9/bits/unique_ptr.h:154
+  25:	48 8b 3b                                              	mov    rdi,QWORD PTR [rbx]
+_ZN6engine5world5World10initializeEv():
+/home/selecaoone/repositories/jumpy/engine/src/lib/world.cpp:25
+  28:	48 8b 07                                              	mov    rax,QWORD PTR [rdi]
+  2b:	ff 50 10                                              	call   QWORD PTR [rax+0x10]


### PR DESCRIPTION
Now that https://github.com/neovim/neovim/pull/23608 and https://github.com/nvim-treesitter/nvim-treesitter/commit/0179a89656b4ce395a4487c07ae385b8425524ae merged, objdump files are recognized in Neovim with tree-sitter support. Adding to nvim-treesitter-context as well.

![nvim-treesitter-context_demo](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/10103049/529501c5-dfcd-49f6-8143-af70fc181109)