### PR TITLE
Update c queries and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ on:
 jobs:
   build:
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        neovim_branch: ['v0.8.2', 'v0.9.1']
+        neovim_branch: ['v0.9.5']
     runs-on: ubuntu-latest
     env:
       NEOVIM_BRANCH: ${{ matrix.neovim_branch }}

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := test
 
-NEOVIM_BRANCH := v0.9.1
+NEOVIM_BRANCH := v0.9.5
 
 FILTER=.*
 

--- a/queries/c/context.scm
+++ b/queries/c/context.scm
@@ -19,6 +19,10 @@
   consequence: (_ (_) @context.end)
 ) @context
 
+(else_clause
+  (_) @context.end
+) @context
+
 (while_statement
   body: (_ (_) @context.end)
 ) @context

--- a/queries/c/context.scm
+++ b/queries/c/context.scm
@@ -20,7 +20,7 @@
 ) @context
 
 (else_clause
-  (_) @context.end
+  (_ (_) @context.end)
 ) @context
 
 (while_statement

--- a/test/test.c
+++ b/test/test.c
@@ -72,5 +72,48 @@ int main(int arg1,
       // comment
     }
 
+  } else if (arg1 == 4) {
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+
+  } else {
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+    // comment
+
   }
 }

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -191,6 +191,7 @@ describe('ts_context', function()
                                       |
       ]]}
 
+      -- func -> if -> for -> do while
       feed'40<C-e>'
       screen:expect{grid=[[
         {7:int}{2: main(}{7:int}{2: arg1,            }|
@@ -208,6 +209,27 @@ describe('ts_context', function()
                                       |
               } {4:while} ({11:1});            |
               {8:// comment}              |
+                                      |
+      ]]}
+
+      -- func -> if / else if / else
+      feed'41<C-e>'
+      screen:expect{grid=[[
+        {7:int}{2: main(}{7:int}{2: arg1,            }|
+        {2:  }{1:if}{2: (arg1 == }{10:4}{2:               }|
+        {2:      && arg2 == arg3) }{13:{}{2:      }|
+        {2:  }{13:}}{2: }{1:else}{2: }{1:if}{2: (arg1 == }{10:4}{2:) }{13:{}{2:     }|
+        {2:  }{13:}}{2: }{1:else}{2: }{13:{}{2:                    }|
+        ^    {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
+            {8:// comment}                |
                                       |
       ]]}
     end)

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -32,12 +32,6 @@ describe('ts_context', function()
     cmd [[let $XDG_CACHE_HOME='scratch/cache']]
     cmd [[set packpath=]]
     cmd('syntax enable')
-
-    exec_lua[[
-      require'nvim-treesitter.configs'.setup {
-        highlight = { enable = true }
-      }
-    ]]
   end)
 
   it('load the plugin', function()


### PR DESCRIPTION
A lot of the current C queries include an extra line with only `{` if you format your code in this style:
```c
if ()
{
  //code
}
for ()
{
  //code
}
```
For the context that whole line with only `{` is wasted space, so this simplifies some queries to not include that `{`. If you want to always include `{` instead, I can update the queries.

Also, this catches `if`, `else if` and `else` with the expected pattern (see #356). 

If the queries should catch the extra "{", then I can rewrite this a bit so it still catches `else if` and `else`, but otherwise doesn't change anything. 

Note: I can rewrite the test that is currently failing if you want to merge this pull request. 