### PR TITLE
feat: add option to show the context with the **folded** current buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,12 @@ require'treesitter-context'.setup{
   multiline_threshold = 20, -- Maximum number of lines to show for a single context
   trim_scope = 'outer', -- Which context lines to discard if `max_lines` is exceeded. Choices: 'inner', 'outer'
   mode = 'cursor',  -- Line used to calculate context. Choices: 'cursor', 'topline'
+  -- Summarizer can be 'set_lines' or 'fold'. The latter recommends nvim >= 0.10.
+  summarizer = 'set_lines',
+  -- The 'foldtext' option for the context window when `summarizer = 'fold'`.
+  -- If `nil` (default), tries `"v:lua.vim.treesitter.foldtext()"` and fallbacks to
+  -- "getline(v:foldstart)"
+  foldtext = nil,
   -- Separator between context and content. Should be a single character string, like '-'.
   -- When separator is set, the context will only show up when there are at least 2 lines above cursorline.
   separator = nil,

--- a/lua/treesitter-context/config.lua
+++ b/lua/treesitter-context/config.lua
@@ -8,6 +8,8 @@
 --- @field trim_scope 'outer'|'inner'
 --- @field zindex integer
 --- @field mode 'cursor'|'topline'
+--- @field summarizer 'set_lines' | 'fold'
+--- @field foldtext? string
 --- @field separator? string
 --- @field on_attach? fun(buf: integer): boolean
 
@@ -52,6 +54,7 @@ local default_config = {
   trim_scope = 'outer',
   zindex = 20,
   mode = 'cursor',
+  summarizer = 'set_lines',
 }
 
 local config = vim.deepcopy(default_config)

--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -62,6 +62,7 @@ local function display_window(bufnr, winid, width, height, col, ty, hl)
     })
     vim.w[winid][ty] = true
     vim.wo[winid].wrap = false
+    vim.wo[winid].signcolumn = 'no'
     vim.wo[winid].winhl = 'NormalFloat:' .. hl
 
     local fold = config.summarizer == 'fold'


### PR DESCRIPTION
By using the **folded** current buffer, the content (including extmark!) is automatically synced among the edit window and the context window.

This allows label-based motion plugins (e.g., [nvim-treehopper](https://github.com/mfussenegger/nvim-treehopper), [flash.nvim](https://github.com/folke/flash.nvim), [treemonkey.nvim](https://github.com/atusy/treemonkey.nvim)) to show the label on the context without hacks.
See example below.

![2023-12-25 21-10-06 mkv](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/30277794/7d4feb11-f5a4-4876-8d20-5bc3a19f0dfc)
