### PR TITLE
chore: ignore test languages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/test/* -linguist-detectable


### PR DESCRIPTION
The language stats are skewed because the Janet test is somehow larger than the entire Lua codebase.