### PR TITLE
feat(hl): add 'TreesitterContextLineNumberBottom'

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,12 +231,21 @@ context line numbers if `line_numbers` is set. Per default it links to `LineNr`.
 Use the highlight group `TreesitterContextSeparator` to change the colors of the
 separator if `separator` is set. By default it links to `FloatBorder`.
 
-Use the highlight group `TreesitterContextBottom` to change the highlight of the
-last line of the context window. By default it links to `NONE`.
-However, you can use this to create a border by applying an underline highlight, e.g:
+Use the highlight groups `TreesitterContextBottom` and/or
+`TreesitterContextLineNumberBottom` to change the highlight of the last line of
+the context window. By default it links to `NONE`.
+However, you can use this to create a border by applying an underline highlight, e.g,
+for an underline across the screen:
 
 ```vim
 hi TreesitterContextBottom gui=underline guisp=Grey
+hi TreesitterContextLineNumberBottom gui=underline guisp=Grey
+```
+
+Or an underline below the line numbers only:
+
+```vim
+hi TreesitterContextLineNumberBottom gui=underline guisp=Grey
 ```
 
 ## Jumping to context (upwards)

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -189,6 +189,7 @@ local function init()
   api.nvim_set_hl(0, 'TreesitterContext', { link = 'NormalFloat', default = true })
   api.nvim_set_hl(0, 'TreesitterContextLineNumber', { link = 'LineNr', default = true })
   api.nvim_set_hl(0, 'TreesitterContextBottom', { link = 'NONE', default = true })
+  api.nvim_set_hl(0, 'TreesitterContextLineNumberBottom', { link = 'TreesitterContextBottom', default = true })
   api.nvim_set_hl(0, 'TreesitterContextSeparator', { link = 'FloatBorder', default = true })
 end
 

--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -224,10 +224,11 @@ end
 
 ---@param bufnr integer
 ---@param row integer
-local function highlight_bottom(bufnr, row)
+---@param hl_group 'TreesitterContextBottom' | 'TreesitterContextLineNumberBottom'
+local function highlight_bottom(bufnr, row, hl_group)
   add_extmark(bufnr, row, 0, {
     end_line = row + 1,
-    hl_group = 'TreesitterContextBottom',
+    hl_group = hl_group,
     hl_eol = true,
   })
 end
@@ -293,7 +294,7 @@ local function render_lno(win, bufnr, contexts, gutter_width)
 
   set_lines(bufnr, lno_text)
   highlight_lno_str(bufnr, lno_text, lno_highlights)
-  highlight_bottom(bufnr, #lno_text - 1)
+  highlight_bottom(bufnr, #lno_text - 1, 'TreesitterContextLineNumberBottom')
 end
 
 ---@param winid? integer
@@ -364,7 +365,7 @@ function M.open(bufnr, winid, ctx_ranges, ctx_lines)
   end
 
   highlight_contexts(bufnr, ctx_bufnr, ctx_ranges)
-  highlight_bottom(ctx_bufnr, win_height - 1)
+  highlight_bottom(ctx_bufnr, win_height - 1, 'TreesitterContextBottom')
   horizontal_scroll_contexts()
 end
 


### PR DESCRIPTION
This closes #383.

For now I replaced `highlight_bottom` with `highlight_lno_bottom`, which will change the current behavior a bit, but also allow for more precise configuration by the user.

If you prefer to keep `highlight_bottom` as it was, I can add it back in together with the new function. 