### PR TITLE
feat: Support context recognition for injected languages

### DIFF
--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -9,23 +9,13 @@ local get_lang = vim.treesitter.language.get_lang or require('nvim-treesitter.pa
 --- @diagnostic disable-next-line:deprecated
 local get_query = vim.treesitter.query.get or vim.treesitter.query.get_query
 
----@param bufnr integer
----@param row integer
----@param col integer
----@return TSNode?
-local function get_node(bufnr, row, col)
-  local root_tree = vim.treesitter.get_parser(bufnr)
-  if not root_tree then
-    return
-  end
+--- @param langtree LanguageTree
+--- @param range Range4
+--- @return TSNode[]?
+local function get_parent_nodes(langtree, range)
+  local tree = langtree:tree_for_range(range, { ignore_injections = true })
+  local n = tree:root():named_descendant_for_range(unpack(range))
 
-  return root_tree:named_node_for_range({ row, col, row, col + 1 })
-end
-
---- @param node TSNode
---- @return TSNode[]
-local function get_parent_nodes(node)
-  local n = node --- @type TSNode?
   local ret = {} --- @type TSNode[]
   while n do
     ret[#ret + 1] = n
@@ -108,12 +98,9 @@ local context_range = cache.memoize(function(node, query)
   end
 end, hash_node)
 
----@param bufnr integer
+---@param lang string
 ---@return Query?
-local function get_context_query(bufnr)
-  --- @type string
-  local lang = assert(get_lang(vim.bo[bufnr].filetype))
-
+local function get_context_query(lang)
   local ok, query = pcall(get_query, lang, 'context')
 
   if not ok then
@@ -182,6 +169,29 @@ end
 
 local M = {}
 
+---@param bufnr integer
+---@param row integer
+---@param col integer
+---@return LanguageTree[]
+local function get_parent_langtrees(bufnr, range)
+  local root_tree = vim.treesitter.get_parser(bufnr)
+  if not root_tree then
+    return {}
+  end
+
+  local parent_langtrees = {root_tree}
+
+  while true do
+    child_langtree = parent_langtrees[#parent_langtrees]:language_for_range(range)
+    if child_langtree == parent_langtrees[#parent_langtrees] then
+      break
+    end
+    parent_langtrees[#parent_langtrees + 1] = child_langtree
+  end
+
+  return parent_langtrees
+end
+
 --- @param bufnr integer
 --- @param winid integer
 --- @return Range4[]?, string[]?
@@ -193,12 +203,6 @@ function M.get(bufnr, winid)
   end
 
   if not pcall(vim.treesitter.get_parser, bufnr) then
-    return
-  end
-
-  local query = get_context_query(bufnr)
-
-  if not query then
     return
   end
 
@@ -220,40 +224,45 @@ function M.get(bufnr, winid)
 
   for offset = 0, max_lines do
     local node_row = row + offset
-
-    local node = get_node(bufnr, node_row, offset == 0 and col or 0)
-    if not node then
-      return
-    end
-
-    local parents = get_parent_nodes(node)
+    local col0 = offset == 0 and col or 0
+    local range = { node_row, col0, node_row, col0 + 1 }
 
     context_ranges = {}
     context_lines = {}
     contexts_height = 0
 
-    for i = #parents, 1, -1 do
-      local parent = parents[i]
-      local parent_start_row = parent:range()
+    local parent_trees = get_parent_langtrees(bufnr, range)
+    for i = 1, #parent_trees, 1 do
+      local langtree = parent_trees[i]
+      local query = get_context_query(langtree:lang())
+      if not query then
+        return
+      end
 
-      local contexts_end_row = top_row + math.min(max_lines, contexts_height)
-      -- Only process the parent if it is not in view.
-      if parent_start_row < contexts_end_row then
-        local range0 = context_range(parent, query)
-        if range0 then
-          local range, lines = get_text_for_range(range0)
+      local parents = get_parent_nodes(langtree, range)
+      for i = #parents, 1, -1 do
+        local parent = parents[i]
+        local parent_start_row = parent:range()
 
-          local last_context = context_ranges[#context_ranges]
-          if last_context and parent_start_row == last_context[1] then
-            -- If there are multiple contexts on the same row, then prefer the inner
-            contexts_height = contexts_height - util.get_range_height(last_context)
-            context_ranges[#context_ranges] = nil
-            context_lines[#context_lines] = nil
+        local contexts_end_row = top_row + math.min(max_lines, contexts_height)
+        -- Only process the parent if it is not in view.
+        if parent_start_row < contexts_end_row then
+          local range0 = context_range(parent, query)
+          if range0 then
+            local range, lines = get_text_for_range(range0)
+
+            local last_context = context_ranges[#context_ranges]
+            if last_context and parent_start_row == last_context[1] then
+              -- If there are multiple contexts on the same row, then prefer the inner
+              contexts_height = contexts_height - util.get_range_height(last_context)
+              context_ranges[#context_ranges] = nil
+              context_lines[#context_lines] = nil
+            end
+
+            contexts_height = contexts_height + util.get_range_height(range)
+            context_ranges[#context_ranges + 1] = range
+            context_lines[#context_lines + 1] = lines
           end
-
-          contexts_height = contexts_height + util.get_range_height(range)
-          context_ranges[#context_ranges + 1] = range
-          context_lines[#context_lines + 1] = lines
         end
       end
     end

--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -225,13 +225,13 @@ function M.get(bufnr, winid)
   for offset = 0, max_lines do
     local node_row = row + offset
     local col0 = offset == 0 and col or 0
-    local range = { node_row, col0, node_row, col0 + 1 }
+    local line_range = { node_row, col0, node_row, col0 + 1 }
 
     context_ranges = {}
     context_lines = {}
     contexts_height = 0
 
-    local parent_trees = get_parent_langtrees(bufnr, range)
+    local parent_trees = get_parent_langtrees(bufnr, line_range)
     for i = 1, #parent_trees, 1 do
       local langtree = parent_trees[i]
       local query = get_context_query(langtree:lang())
@@ -239,9 +239,9 @@ function M.get(bufnr, winid)
         return
       end
 
-      local parents = get_parent_nodes(langtree, range)
-      for i = #parents, 1, -1 do
-        local parent = parents[i]
+      local parents = get_parent_nodes(langtree, line_range)
+      for j = #parents, 1, -1 do
+        local parent = parents[j]
         local parent_start_row = parent:range()
 
         local contexts_end_row = top_row + math.min(max_lines, contexts_height)

--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -182,8 +182,16 @@ local function get_parent_langtrees(bufnr, range)
   local parent_langtrees = {root_tree}
 
   while true do
-    child_langtree = parent_langtrees[#parent_langtrees]:language_for_range(range)
-    if child_langtree == parent_langtrees[#parent_langtrees] then
+    local child_langtree = nil
+
+    for _, langtree in pairs(parent_langtrees[#parent_langtrees]:children()) do
+      if langtree:contains(range) then
+        child_langtree = langtree
+        break
+      end
+    end
+
+    if child_langtree == nil then
       break
     end
     parent_langtrees[#parent_langtrees + 1] = child_langtree

--- a/test/test.html
+++ b/test/test.html
@@ -132,6 +132,20 @@
     var b = 2;
     function test() {
       let test = "asdasd";
+
+
+
+      if test != "" {
+
+
+
+
+
+
+
+
+
+      }
     }
 
     var c = a + b;

--- a/test/test.html
+++ b/test/test.html
@@ -132,20 +132,6 @@
     var b = 2;
     function test() {
       let test = "asdasd";
-
-
-
-      if test != "" {
-
-
-
-
-
-
-
-
-
-      }
     }
 
     var c = a + b;

--- a/test/test.md
+++ b/test/test.md
@@ -1,29 +1,27 @@
 ```html
 <html>
-    <body>
-
-        
+  <body>
 
 
 
 
 
 
-
-        <script>
-
+    <script>
 
 
 
 
 
-            function test() {
 
 
 
-              if test != "" {
 
 
+
+
+      function test() {
+        if test != "" {
 
 
 
@@ -37,13 +35,11 @@
 
 
 
-              }
-            }
-
-        </script>
 
 
-
-    </body>
+        }
+      }
+    </script>
+  </body>
 </html>
 ```

--- a/test/test.md
+++ b/test/test.md
@@ -1,0 +1,49 @@
+```html
+<html>
+    <body>
+
+        
+
+
+
+
+
+
+
+        <script>
+
+
+
+
+
+
+            function test() {
+
+
+
+              if test != "" {
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+              }
+            }
+
+        </script>
+
+
+
+    </body>
+</html>
+```

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -46,6 +46,9 @@ describe('ts_context', function()
       sync_install = true,
     }
     ]]
+    -- Required for the proper Markdown support
+    exec_lua [[require'nvim-treesitter.query_predicates']]
+
     cmd [[let $XDG_CACHE_HOME='scratch/cache']]
     cmd [[set packpath=]]
     cmd('syntax enable')
@@ -334,15 +337,37 @@ describe('ts_context', function()
       cmd('edit test/test.md')
       exec_lua [[vim.treesitter.start()]]
 
-      feed'2<C-e>'
+      feed'3<C-e>'
       screen:expect{grid=[[
         {14:<html>}{2:                        }|
         {2:  }{14:<body>}{2:                      }|
                                       |*3
         ^                              |
-                                      |*4
-              {15:<script>}                   |
-                                      |*6
+            {15:<script>}                  |
+                                      |*9
+      ]]}
+
+      feed'5<C-e>'
+      screen:expect{grid=[[
+        {14:<html>}{2:                        }|
+        {2:  }{14:<body>}{2:                      }|
+        {2:    }{14:<script>}{2:                  }|
+                                      |*2
+        ^                              |
+                                      |*8
+              {4:function} {5:test}{15:()} {15:{}       |
+                                      |
+      ]]}
+
+      feed'12<C-e>'
+      screen:expect{grid=[[
+        {14:<html>}{2:                        }|
+        {2:  }{14:<body>}{2:                      }|
+        {2:    }{14:<script>}{2:                  }|
+        {2:      }{1:function}{2: }{3:test}{14:()}{2: }{14:{}{2:       }|
+        {2:        }{1:if}{2: }{3:test}{2: }{1:!=}{2: }{10:""}{2: }{14:{}{2:       }|
+        ^                              |
+                                      |*10
       ]]}
     end)
   end)

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -42,6 +42,8 @@ describe('ts_context', function()
         "cpp",
         "typescript",
         "markdown",
+        "html",
+        "javascript",
       },
       sync_install = true,
     }

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -49,7 +49,7 @@ describe('ts_context', function()
     }
     ]]
     -- Required for the proper Markdown support
-    exec_lua [[require'nvim-treesitter.query_predicates']]
+    exec_lua [[require'nvim-treesitter'.setup()]]
 
     cmd [[let $XDG_CACHE_HOME='scratch/cache']]
     cmd [[set packpath=]]

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -41,8 +41,7 @@ describe('ts_context', function()
         "rust",
         "cpp",
         "typescript",
-        "html",
-        "javascript",
+        "markdown",
       },
       sync_install = true,
     }
@@ -331,50 +330,19 @@ describe('ts_context', function()
       ]]}
     end)
 
-    it('html', function()
-      cmd('edit test/test.html')
+    it('markdown', function()
+      cmd('edit test/test.md')
       exec_lua [[vim.treesitter.start()]]
 
-      feed'100<C-e>'
+      feed'2<C-e>'
       screen:expect{grid=[[
-        {14:<html}{2: }{14:lang}{1:=}{10:"en"}{14:>}{2:              }|
+        {14:<html>}{2:                        }|
         {2:  }{14:<body>}{2:                      }|
-        {2:    }{14:<ul>}{2:                      }|
-        {2:      }{14:<li>}{2:                    }|
-                                      |
+                                      |*3
         ^                              |
-                                      |*5
-              {15:</li>}                   |
-              {15:<li></li>}               |
-            {15:</ul>}                     |
-          {15:</body>}                     |
-                                      |
-      ]]}
-
-      feed'31<C-e>'
-      screen:expect{grid=[[
-        {14:<html}{2: }{14:lang}{1:=}{10:"en"}{14:>}{2:              }|
-        {2:  }{14:<script>}{2:                    }|
-        {2:    }{1:function}{2: }{3:test}{14:()}{2: }{14:{}{2:         }|
-                                      |
-                                      |
-        ^                              |
-              {4:if} {5:test} {4:!=} {11:""} {15:{}         |
-                                      |*9
-      ]]}
-
-      feed'4<C-e>'
-      screen:expect{grid=[[
-        {14:<html}{2: }{14:lang}{1:=}{10:"en"}{14:>}{2:              }|
-        {2:  }{14:<script>}{2:                    }|
-        {2:    }{1:function}{2: }{3:test}{14:()}{2: }{14:{}{2:         }|
-        {2:      }{1:if}{2: }{3:test}{2: }{1:!=}{2: }{10:""}{2: }{14:{}{2:         }|
-                                      |
-        ^                              |
+                                      |*4
+              {15:<script>}                   |
                                       |*6
-              {15:}}                       |
-            {15:}}                         |
-                                      |*2
       ]]}
     end)
   end)

--- a/test/ts_context_spec.lua
+++ b/test/ts_context_spec.lua
@@ -40,7 +40,9 @@ describe('ts_context', function()
         "lua",
         "rust",
         "cpp",
-        "typescript"
+        "typescript",
+        "html",
+        "javascript",
       },
       sync_install = true,
     }
@@ -329,6 +331,52 @@ describe('ts_context', function()
       ]]}
     end)
 
+    it('html', function()
+      cmd('edit test/test.html')
+      exec_lua [[vim.treesitter.start()]]
+
+      feed'100<C-e>'
+      screen:expect{grid=[[
+        {14:<html}{2: }{14:lang}{1:=}{10:"en"}{14:>}{2:              }|
+        {2:  }{14:<body>}{2:                      }|
+        {2:    }{14:<ul>}{2:                      }|
+        {2:      }{14:<li>}{2:                    }|
+                                      |
+        ^                              |
+                                      |*5
+              {15:</li>}                   |
+              {15:<li></li>}               |
+            {15:</ul>}                     |
+          {15:</body>}                     |
+                                      |
+      ]]}
+
+      feed'31<C-e>'
+      screen:expect{grid=[[
+        {14:<html}{2: }{14:lang}{1:=}{10:"en"}{14:>}{2:              }|
+        {2:  }{14:<script>}{2:                    }|
+        {2:    }{1:function}{2: }{3:test}{14:()}{2: }{14:{}{2:         }|
+                                      |
+                                      |
+        ^                              |
+              {4:if} {5:test} {4:!=} {11:""} {15:{}         |
+                                      |*9
+      ]]}
+
+      feed'4<C-e>'
+      screen:expect{grid=[[
+        {14:<html}{2: }{14:lang}{1:=}{10:"en"}{14:>}{2:              }|
+        {2:  }{14:<script>}{2:                    }|
+        {2:    }{1:function}{2: }{3:test}{14:()}{2: }{14:{}{2:         }|
+        {2:      }{1:if}{2: }{3:test}{2: }{1:!=}{2: }{10:""}{2: }{14:{}{2:         }|
+                                      |
+        ^                              |
+                                      |*6
+              {15:}}                       |
+            {15:}}                         |
+                                      |*2
+      ]]}
+    end)
   end)
 
 end)


### PR DESCRIPTION
Currently, the plugin only recognizes the outermost language of a file, disregarding any injected languages within the file. A notable example are `.html` files, where JavaScript content within `<script>` tags is ignored.

The root cause of this behavior lies in the fact that, during context evaluation for a line, only the root language tree is considered. Fortunately, the `nvim-treesitter` API provides a solution by allowing us to retrieve all language trees associated with a given range (`LanguageTree:language_for_range({range})`).

This PR proposes a simple yet effective change: iterating over parent nodes of each language tree detected for the range, as opposed to doing so only for the root language tree.

I believe, introduced functionality aims to enhance the plugin's behavior without overcomplicating the source code. It particularly improves compatibility with JavaScript frameworks like Svelte or Vue, where language injection is common, if not inevitable.

To illustrate the impact of this PR, below there is a comparison of the plugin's behavior on `test/test.html` file before (left side) and after introducing the changes (right side):

[![asciicast](https://asciinema.org/a/xFHwOBAEm2ZBzUGsP9bI1oLFz.svg)](https://asciinema.org/a/xFHwOBAEm2ZBzUGsP9bI1oLFz)