### PR TITLE
fix: crashes on lines with invalid syntax

### DIFF
--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -14,6 +14,10 @@ local get_query = vim.treesitter.query.get or vim.treesitter.query.get_query
 --- @return TSNode[]?
 local function get_parent_nodes(langtree, range)
   local tree = langtree:tree_for_range(range, { ignore_injections = true })
+  if tree == nil then
+    return
+  end
+
   local n = tree:root():named_descendant_for_range(unpack(range))
 
   local ret = {} --- @type TSNode[]
@@ -248,6 +252,10 @@ function M.get(bufnr, winid)
       end
 
       local parents = get_parent_nodes(langtree, line_range)
+      if parents == nil then
+        return
+      end
+
       for j = #parents, 1, -1 do
         local parent = parents[j]
         local parent_start_row = parent:range()


### PR DESCRIPTION
Fixes #397

In #388 we have slightly refactored logic for acquiring langtree nodes for a line, and we did not recreate error handling logic existing previously. Thus, in case if the tree node for the given line cannot be found (e.g. due to the invalid syntax), the plugin crashes. Restoring the null handling seems to resolve the entire problem.