### PR TITLE
feat: make max_lines accept percentage (of window height) or function

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ Note: calling `setup()` is optional.
 ```lua
 require'treesitter-context'.setup{
   enable = true, -- Enable this plugin (Can be enabled/disabled later via commands)
-  max_lines = 0, -- How many lines the window should span. Values <= 0 mean no limit.
+  max_lines = 0, -- How many lines the window should span. It can be a number, a string percentage 
+  -- e.g., "5%" or a function that can return both. Numbers <= 0 mean no limit."
   min_window_height = 0, -- Minimum editor window height to enable context. Values <= 0 mean no limit.
   line_numbers = true,
   multiline_threshold = 20, -- Maximum number of lines to show for a single context

--- a/lua/treesitter-context/config.lua
+++ b/lua/treesitter-context/config.lua
@@ -1,7 +1,6 @@
-
 --- @class (exact) TSContext.Config
 --- @field enable boolean
---- @field max_lines integer
+--- @field max_lines integer | string | fun(): integer|string
 --- @field min_window_height integer
 --- @field line_numbers boolean
 --- @field multiline_threshold integer
@@ -16,8 +15,9 @@
 --- Enable this plugin (Can be enabled/disabled later via commands)
 --- @field enable? boolean
 ---
---- How many lines the window should span. Values <= 0 mean no limit.
---- @field max_lines? integer
+--- How many lines the window should span. It can be a number, a string percentage
+--- e.g., "5%" or a function that can return both. Numbers <= 0 mean no limit."
+--- @field max_lines? integer | string | fun(): integer|string
 ---
 --- Minimum editor window height to enable context. Values <= 0 mean no limit.
 --- @field min_window_height? integer
@@ -67,7 +67,7 @@ end
 setmetatable(M, {
   __index = function(_, k)
     return config[k]
-  end
+  end,
 })
 
 return M


### PR DESCRIPTION
Closes https://github.com/nvim-treesitter/nvim-treesitter-context/issues/275

Add the possibility of providing a percentage string of `max_lines` e.g., "5%"; or a function that returns a number or a percentage string.

Notes:

- Looking at the config fields I see that `max_lines` should be an `integer`, but I couldn't force that ( due to not having `math.type` in lua 5.1) so I just checked against `number`. Is this a problem?
- Related to type annotations. I don't know if it is because of my local lsp config, but the `max_lines` type is not inferred correctly. 
- Some formatting changes were made. I assume it's because of the stylua local file and not my config, tell me if I should revert them.

If there is something that I need to change let me know!