### PR TITLE
feat: add context for c++ namespace definition

### DIFF
--- a/queries/cpp/context.scm
+++ b/queries/cpp/context.scm
@@ -4,6 +4,10 @@
   body: (_ (_) @context.end)
 ) @context
 
+(namespace_definition
+  body: (_ (_) @context.end)
+) @context
+
 (class_specifier
   body: (_ (_) @context.end)
 ) @context


### PR DESCRIPTION
Sometimes in complex c++ headers with several namespaces it's a bit hard to orient in which namespace you are currently working. Typically, there is one "public" namespace, and one "internal", and the file looks like this:

```c++
namespace public {
  // some code
namespace internal {
  // some code
}
  // some code
}
```

The proposal is to add the namespace definition as the context line.