### PR TITLE
fix: avoid propagating empty context_lines

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -106,7 +106,10 @@ local update = throttle(function()
     return
   end
 
-  assert(context_lines)
+  if not context_lines or #context_lines == 0 then
+    close()
+    return
+  end
 
   open(bufnr, winid, context, context_lines)
 end)


### PR DESCRIPTION
# Description

This PR fixes an issue where sometime the `ctx_lines` used to define the `height` were empty, triggering an error about invalid height:

```
lua/treesitter-context/render.lua:51: 'height' key must be a positive Integer
```

The fix is checking if the `context_lines` are not empty, if it is, the `close` method is called.


## PR Checklist:

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added or updated tests that comprehensively prove my change is effective or that my feature works
