### PR TITLE
feat: add Tact queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Note: if you need support for Neovim 0.6.x please use the tag `compat/0.6`.
   - [x] `solidity`
   - [x] `svelte`
   - [x] `swift`
+  - [x] `tact`
   - [x] `tcl`
   - [x] `teal`
   - [x] `templ`

--- a/queries/tact/context.scm
+++ b/queries/tact/context.scm
@@ -1,0 +1,101 @@
+; See: https://github.com/nvim-treesitter/nvim-treesitter-context/blob/master/CONTRIBUTING.md
+; storage types
+; -------------
+(struct
+  body: (_
+    (_) @context.end)) @context
+
+(message
+  body: (_
+    (_) @context.end)) @context
+
+(contract
+  body: (_
+    (_) @context.end)) @context
+
+(trait
+  body: (_
+    (_) @context.end)) @context
+
+; functions
+; ---------
+(static_function
+  body: (_
+    (_) @context.end)) @context
+
+(init_function
+  body: (_
+    (_) @context.end)) @context
+
+(receive_function
+  body: (_
+    (_) @context.end)) @context
+
+(external_function
+  body: (_
+    (_) @context.end)) @context
+
+(bounced_function
+  body: (_
+    (_) @context.end)) @context
+
+(function
+  body: (_
+    (_) @context.end)) @context
+
+; statements
+; ----------
+(if_statement
+  consequence: (_
+    (_) @context.end)) @context
+
+(else_clause
+  (_
+    (_) @context.end)) @context
+
+(try_statement
+  body: (_
+    (_) @context.end)) @context
+
+(catch_clause
+  body: (_
+    (_) @context.end)) @context
+
+(while_statement
+  body: (_
+    (_) @context.end)) @context
+
+(repeat_statement
+  body: (_
+    (_) @context.end)) @context
+
+(do_until_statement
+  body: (_
+    (_) @context.end)) @context
+
+(foreach_statement
+  body: (_
+    (_) @context.end)) @context
+
+[
+  (return_statement)
+  (expression_statement)
+] @context
+
+; expressions
+; -----------
+(method_call_expression
+  arguments: (_
+    (_) @context.end)) @context
+
+(static_call_expression
+  arguments: (_
+    (_) @context.end)) @context
+
+(instance_expression
+  arguments: (_
+    (_) @context.end)) @context
+
+(initOf
+  arguments: (_
+    (_) @context.end)) @context

--- a/test/test.tact
+++ b/test/test.tact
@@ -1,0 +1,183 @@
+struct S {
+
+
+
+
+    // comment
+}
+
+message M {
+
+
+
+
+    // comment
+}
+
+trait C {
+
+
+
+
+    // comment
+}
+
+contract C {
+    init() {
+
+
+
+
+        // comment
+    }
+
+    receive() {
+
+
+
+
+        // comment
+    }
+
+    external() {
+
+
+
+
+        // comment
+    }
+
+    bounced(msg: bounced<M>) {
+
+
+
+
+        // comment
+    }
+
+    fun someFunction() {
+
+
+
+
+        // comment
+    }
+}
+
+fun statements() {
+    let a: map<Int, Int> = null;
+    
+    if (true) {
+
+
+
+
+        // comment
+    } else {
+
+
+
+
+        // comment
+    }
+
+    try {
+
+
+
+
+        // comment
+    } catch (e) {
+        
+
+
+
+        // comment
+    }
+
+    while (true) {
+        
+
+
+
+        // comment
+    }
+
+    repeat (5) {
+        
+
+
+
+        // comment
+    }
+
+    do {
+        
+
+
+
+        // comment
+    } until (true);
+
+    foreach (k, v in a) {
+        
+
+
+
+        // comment
+    }
+
+    // expression_statement
+    0
+
+
+
+
+    // comment
+    ;
+
+    // return_statement
+    return
+    
+
+
+
+    // comment
+    0;
+
+    // method_call_expression
+    0.toString(
+
+
+
+
+        // comment
+    );
+
+    // static_call_expression
+    ton(
+
+
+
+
+        "0.1" // comment
+    );
+
+    // instance_expression
+    S {
+
+
+
+
+        // comment
+    };
+
+    // initOf_expression
+    initOf C(
+
+
+
+
+        // comment
+    );
+}


### PR DESCRIPTION
* Queries `context.scm` in queries/tact (formatted according to [format-queries.lua](https://github.com/nvim-treesitter/nvim-treesitter/blob/main/scripts/format-queries.lua))
* Tests `test.tact` in test/
* Updated README to mention Tact is supported

Tree-sitter grammar/parser for Tact lives here: https://github.com/tact-lang/tree-sitter-tact
I'll be making similar PRs to textobjects and the main nvim-treesitter repo in a short while. Hope everything's good here :)