### PR TITLE
fix: height error while scrolling down

### DIFF
--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -336,7 +336,7 @@ function M.open(bufnr, winid, ctx_ranges, ctx_lines)
   local gutter_width = get_gutter_width(winid)
   local win_width = math.max(1, api.nvim_win_get_width(winid) - gutter_width)
 
-  local win_height = #ctx_lines
+  local win_height = math.max(1, #ctx_lines)
 
   local gbufnr, ctx_bufnr = get_bufs()
 


### PR DESCRIPTION
Fix #431.
Scrolling down in a file when the first line is empty causes an error.

```
Error detected while processing WinScrolled Autocommands for "*":
Error executing lua callback: ...vim-treesitter-context/lua/treesitter-context/render.lua:51: 'height' key must be a positive Integer
stack traceback:
        [C]: in function 'nvim_open_win'
        ...vim-treesitter-context/lua/treesitter-context/render.lua:51: in function 'display_window'
        ...vim-treesitter-context/lua/treesitter-context/render.lua:354: in function 'open'
        .../lazy/nvim-treesitter-context/lua/treesitter-context.lua:50: in function 'open'
        .../lazy/nvim-treesitter-context/lua/treesitter-context.lua:111: in function 'f'
        .../lazy/nvim-treesitter-context/lua/treesitter-context.lua:27: in function <.../lazy/nvim-treesitter-context/lua/treesitter-context.lua:21
```