### PR TITLE
feat: add elm support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Note: if you need support for Neovim 0.6.x please use the tag `compat/0.6`.
   - [x] `d`
   - [x] `dart`
   - [x] `elixir`
+  - [x] `elm`
   - [x] `fennel`
   - [x] `fish`
   - [x] `fortran`
@@ -109,7 +110,6 @@ Note: if you need support for Neovim 0.6.x please use the tag `compat/0.6`.
   - [ ] `ebnf`
   - [ ] `ecma`
   - [ ] `eex`
-  - [ ] `elm`
   - [ ] `elsa`
   - [ ] `elvish`
   - [ ] `embedded_template`

--- a/queries/elm/context.scm
+++ b/queries/elm/context.scm
@@ -1,0 +1,5 @@
+([
+  (value_declaration)
+  (case_of_expr)
+  (case_of_branch)
+] @context)

--- a/test/test.elm
+++ b/test/test.elm
@@ -1,0 +1,84 @@
+module Test exposing (..)
+
+import Html exposing (div, text)
+
+
+main : Html.Html msg
+main =
+    let
+        test =
+            "Test content"
+    in
+    case test of
+        "Hello" ->
+            div []
+                [ text "Hello, World!"
+                , -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  -- Generate some lines
+                  div []
+                    [ text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    , text "Some more lines"
+                    ]
+                ]
+
+        _ ->
+            text "Default"


### PR DESCRIPTION
Support elm https://elm-lang.org/

Adding type annotations support for functions would be great, but I don't have the required parser skills for now.

- [x] `context.scm` file added
- [x] `test/test.elm` file added
- [x] README.md modified with elm support