### PR TITLE
Fixes for Ruby language support

### DIFF
--- a/queries/ruby/context.scm
+++ b/queries/ruby/context.scm
@@ -2,6 +2,10 @@
   (body_statement) @context.end
 ) @context
 
+(singleton_class
+  (body_statement) @context.end
+) @context
+
 (module
   (body_statement) @context.end
 ) @context

--- a/queries/ruby/context.scm
+++ b/queries/ruby/context.scm
@@ -47,7 +47,7 @@
    "include_examples"
    "include_context"
    "context"
-   "description"
+   "describe"
    "shared_context"
    "shared_examples")
 ) @context


### PR DESCRIPTION
This PR contains two fixes for the Ruby/RSpec `.scm`.

Firstly, capturing as context `singleton_class` nodes:

```ruby
class Foo
  class << self # this should count as context
    def run
      # ...
    end
  end
end
```

Secondly, correcting an RSpec type - `describe` blocks are used, not `description`:

```ruby
describe 'foo' do
  context 'bar' do
    # ...
  end
end
```
