### PR TITLE
fix(swift): add lambda_literal

### DIFF
--- a/queries/swift/context.scm
+++ b/queries/swift/context.scm
@@ -40,3 +40,8 @@
 (guard_statement
   (statements) @context.end
 ) @context
+
+(lambda_literal
+  (statements) @context.end
+) @context
+


### PR DESCRIPTION
Add lambda_literal, which also defines a context in Swift and is used extensively in the language in the form of trailing closures.