### PR TITLE
add lambda_expression context for cpp

### DIFF
--- a/queries/cpp/context.scm
+++ b/queries/cpp/context.scm
@@ -15,3 +15,7 @@
 (linkage_specification
   body: (declaration_list (_) @context.end)
 ) @context
+
+(lambda_expression
+  body: (_ (_) @context.end)
+) @context


### PR DESCRIPTION
This PR adds context display for long bodies of lambda expressions. Works for me.

Regarding https://github.com/nvim-treesitter/nvim-treesitter-context/issues/466