### PR TITLE
Add missing ruby context patterns 

### DIFF
--- a/queries/ruby/context.scm
+++ b/queries/ruby/context.scm
@@ -51,3 +51,37 @@
    "shared_context"
    "shared_examples")
 ) @context
+
+(case
+  (when (_) @context.end)*
+  (else (_) @context.end)?
+) @context
+
+(for
+  (_) @context.end
+) @context
+
+(while
+  (_) @context.end
+) @context
+
+(until
+  (_) @context.end
+) @context
+
+(begin
+  (_) @context.end
+) @context
+
+(rescue
+  (_) @context.end
+) @context
+
+(ensure
+  (_) @context.end
+) @context
+
+(lambda
+  (_) @context.end
+) @context
+


### PR DESCRIPTION
### Motivation
Resolves https://github.com/nvim-treesitter/nvim-treesitter-context/issues/469 where some context queries are not taken into account.

### Changes
Add the following ruby context patterns:

1. `case`
2. `for`
3. `while`
4. `until`
5. `begin`
6. `rescue`
7.  `ensure`
8. `lambda`

### Example
Here is how the example from https://github.com/nvim-treesitter/nvim-treesitter-context/issues/469 is handled now:
![Screenshot 2024-07-05 at 3 35 03 PM](https://github.com/nvim-treesitter/nvim-treesitter-context/assets/26261714/a7b8e2f1-903e-4069-897f-018be3fe0966)

