### PR TITLE
feat(devicetree): add devicetree support

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Note: support for specific languages is strictly community maintained and can br
   - [x] `cue`
   - [x] `d`
   - [x] `dart`
+  - [x] `devicetree`
   - [x] `elixir`
   - [x] `elm`
   - [x] `fennel`
@@ -107,7 +108,6 @@ Note: support for specific languages is strictly community maintained and can br
   - [ ] `commonlisp`
   - [ ] `cooklang`
   - [ ] `cpon`
-  - [ ] `devicetree`
   - [ ] `dhall`
   - [ ] `dockerfile`
   - [ ] `dot`

--- a/queries/devicetree/context.scm
+++ b/queries/devicetree/context.scm
@@ -1,0 +1,1 @@
+(node) @context

--- a/test/lang/test.dts
+++ b/test/lang/test.dts
@@ -1,0 +1,18 @@
+/dts-v1/;
+
+// {{TEST}}
+
+/ { // {{CONTEXT}}
+    compatible = "test";
+    #address-cells = <2>;
+    #size-cells = <2>;
+
+    soc { // {{CONTEXT}}
+        compatible = "simple-bus";
+        ranges;
+        #address-cells = <2>;
+        #size-cells = <2>;
+
+        // {{CURSOR}}
+    };
+};


### PR DESCRIPTION
This adds support for devicetree source (dts) files.