### PR TITLE
Fix query:iter_matches for nvim 0.11

### DIFF
--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -75,9 +75,14 @@ local context_range = cache.memoize(function(node, query)
   for _, match in query:iter_matches(node, bufnr, 0, -1, { max_start_depth = 0, all = false }) do
     local r = false
 
-    --- @cast match table<integer,TSNode>
+    --- @cast match table<integer,table<TSNode>>
 
     for id, node0 in pairs(match) do
+      -- default type is a table starting in nvim 0.11
+      if type(node0) == 'table' then
+        node0 = node0[#node0]
+      end
+        
       local srow, scol, erow, ecol = node0:range()
 
       local name = query.captures[id] -- name of the capture in the query


### PR DESCRIPTION
When starting nvim with treesitter-context on the newist nightly, there are a lot of error messages. This is because https://github.com/neovim/neovim/commit/6913c5e1d975a11262d08b3339d50b579e6b6bb8 changed the default return of query:iter_matches.
This pr fixes this, while remaining backwards compatible.
There is also the option to use the old behavior with { all = false }, but since this will be removed in future versions, I think its a better idea to solve it in code.