### PR TITLE
Add treesitter queries for switch and switch label

### DIFF
--- a/queries/java/context.scm
+++ b/queries/java/context.scm
@@ -18,4 +18,8 @@
   body: (_) @context.end
 ) @context
 
+(switch_expression) @context
+
+(switch_block_statement_group) @context
+
 (expression_statement) @context


### PR DESCRIPTION
Allows to see which switch and which case you are in:

![image](https://github.com/user-attachments/assets/1c996023-2b80-45f3-afb0-6a3e5e39d8c4)
