### PR TITLE
feat: extmarks copy filtering support

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ require'treesitter-context'.setup{
   separator = nil,
   zindex = 20, -- The Z-index of the context window
   on_attach = nil, -- (fun(buf: integer): boolean) return false to disable attaching
+  filter_extmarks = nil, -- (fun(extmark: [integer, integer, integer, vim.api.keyset.extmark_details]): boolean) filter out extmarks that should not be copied over
 }
 ```
 

--- a/lua/treesitter-context/config.lua
+++ b/lua/treesitter-context/config.lua
@@ -11,6 +11,7 @@
 --- @field mode 'cursor'|'topline'
 --- @field separator? string
 --- @field on_attach? fun(buf: integer): boolean
+--- @field filter_extmarks? fun(extmark: [integer, integer, integer, vim.api.keyset.extmark_details]): boolean
 
 --- @class (exact) TSContext.UserConfig : TSContext.Config
 ---
@@ -45,6 +46,9 @@
 ---
 --- Callback when attaching. Return false to disable attaching
 --- @field on_attach? fun(buf: integer): boolean
+---
+--- Callback to filter out extmarks that should not be copied over
+--- @field filter_extmarks? fun(extmark: [integer, integer, integer, vim.api.keyset.extmark_details]): boolean
 
 --- @type TSContext.Config
 local default_config = {
@@ -57,6 +61,7 @@ local default_config = {
   trim_scope = 'outer',
   zindex = 20,
   mode = 'cursor',
+  filter_extmarks = nil,
 }
 
 local config = vim.deepcopy(default_config)


### PR DESCRIPTION
Callback to filter out extmarks that should not be copied over.
Adding this because I needed a way to hide indent-blankline in context window.
```lua
{
    "nvim-treesitter/nvim-treesitter-context",
    opts = {
        filter_extmarks = function(extmark)
          return extmark[4].ns_id ~= vim.api.nvim_get_namespaces()["indent_blankline"]
        end
      }
  },

```