### PR TITLE
fix: on_attach() return false to disable attaching

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -134,10 +134,6 @@ local function autocmd(event, callback, opts)
 end
 
 function M.enable()
-  local cbuf = api.nvim_get_current_buf()
-
-  attached[cbuf] = true
-
   local update_events = {
     'WinScrolled',
     'BufEnter',


### PR DESCRIPTION
# goal
Fix #520 

# how it was tested
1. made sure minimal testcase in #283 still works (see 2182556aab4524b4fa8d00031bf1228ea2e4a023)
2. made sure `on_attach()` return `false` does not display context (see minimal testcase in #520 )
3. made sure `on_attach()` return `true` display context (see minimal testcase in #520 )