### PR TITLE
fix: defer execution to avoid segfaults and fix throttler

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -29,7 +29,7 @@ local function throttle_by_id(f, ms)
     f(id) -- first call, execute immediately
     timers[id]:start(ms, 0, function()
       if waiting[id] then
-        vim.schedule(function() f(id) end) -- only execute if there are calls waiting
+        f(id) -- only execute if there are calls waiting
       end
       waiting[id] = nil
       timers[id] = nil
@@ -173,7 +173,6 @@ function M.enable()
 
   if config.multiwindow then
     table.insert(update_events, 'WinResized')
-    table.insert(update_events, 'WinLeave')
   end
 
   autocmd(update_events, update)
@@ -189,7 +188,7 @@ function M.enable()
   if config.multiwindow then
     autocmd({ 'WinClosed' }, close)
   else
-    autocmd({ 'BufLeave', 'WinLeave', 'WinClosed' }, close)
+    autocmd({ 'WinLeave', 'WinClosed' }, close)
   end
 
   autocmd('User', close, { pattern = 'SessionSavePre' })


### PR DESCRIPTION
Should fix https://github.com/nvim-treesitter/nvim-treesitter-context/issues/522 reliably.
It is inspired by the satellite.nvim plugin https://github.com/lewis6991/satellite.nvim/blob/main/lua/satellite.lua#L74,  which is more stable and consistently uses deferred execution. In contrast, the current implementation sometimes uses deferred execution and other times executes callbacks in-place, when they are not throttled.

Also, there was a problem with throttler, the following execution was possible:
```
  Time ->
|cb|-----timeout-------|cb||cb|-----timeout-----|cb||cb| ...
```