### PR TITLE
feat(proto): add contexts for service blocks

### DIFF
--- a/queries/proto/context.scm
+++ b/queries/proto/context.scm
@@ -1,4 +1,5 @@
 ([
   (enum)
   (message)
+  (service)
 ] @context)

--- a/test/lang/test.proto
+++ b/test/lang/test.proto
@@ -92,8 +92,45 @@ message SomeMessage { // {{CONTEXT}}
 
 
 
+// {{TEST}}
+service SomeService { // {{CONTEXT}}
+
+        rpc SomeMethod(SomeMessage) returns (SomeMessage);
+
+        rpc AnotherMethod(SomeMessage) returns (SomeMessage);
 
 
+
+
+
+
+
+
+
+
+
+        rpc GetRandomUser(SomeMessage) returns (SomeMessage);
+        
+        rpc GenerateRandomData(SomeMessage) returns (SomeMessage);
+        
+        rpc FetchRandomStats(SomeMessage) returns (SomeMessage);
+        
+        rpc CreateRandomProfile(SomeMessage) returns (SomeMessage);
+        
+        rpc ComputeRandomMetrics(SomeMessage) returns (SomeMessage);
+
+
+
+
+
+
+
+
+
+
+
+	// {{CURSOR}}
+}
 
 
 


### PR DESCRIPTION
Have some long service definitions in my company and noticed the context didn't work for these.
This PR adds support for a context to the long service definition.
