### PR TITLE
feat(js/ts/tsx): for in, for of, and switch context

### DIFF
--- a/queries/javascript/context.scm
+++ b/queries/javascript/context.scm
@@ -9,6 +9,7 @@
   (else_clause)
   (expression_statement)
   (for_statement)
+  (for_in_statement)
   (function_declaration)
   (generator_function_declaration)
   (jsx_element)

--- a/queries/tsx/context.scm
+++ b/queries/tsx/context.scm
@@ -8,6 +8,7 @@
   (else_clause)
   (expression_statement)
   (for_statement)
+  (for_in_statement)
   (interface_declaration)
   (jsx_element)
   (jsx_self_closing_element)
@@ -16,6 +17,8 @@
   (object)
   (pair)
   (while_statement)
+  (switch_statement)
+  (switch_case)
 ] @context)
 
 (arrow_function

--- a/queries/typescript/context.scm
+++ b/queries/typescript/context.scm
@@ -8,12 +8,15 @@
   (else_clause)
   (expression_statement)
   (for_statement)
+  (for_in_statement)
   (interface_declaration)
   (lexical_declaration)
   (method_definition)
   (object)
   (pair)
   (while_statement)
+  (switch_statement)
+  (switch_case)
 ] @context)
 
 (arrow_function


### PR DESCRIPTION
Queries for matching `for of` `for in` and `switch` expressions in `javascript`, `typescript` and `tsx`
Note that both `for in` and `for of` are matched by `for_in_statement` query
Closes #529 