### PR TITLE
fix: LspRequest compatiblity with v0.9.5

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -188,6 +188,15 @@ local function is_semantic_tokens_request(req)
     )
 end
 
+--- @param args table
+local function semantic_update(args)
+  if is_semantic_tokens_request(args.data.request) then
+    vim.schedule(function()
+      update(args)
+    end)
+  end
+end
+
 function M.enable()
   if enabled then
     -- Some options may have changed.
@@ -236,13 +245,9 @@ function M.enable()
   autocmd('User', close, { pattern = 'SessionSavePre' })
   autocmd('User', update, { pattern = 'SessionSavePost' })
 
-  autocmd('LspRequest', function(args)
-    if is_semantic_tokens_request(args.data.request) then
-      vim.schedule(function()
-        update(args)
-      end)
-    end
-  end)
+  if vim.fn.has('nvim-0.10') == 1 then
+    autocmd('LspRequest', semantic_update)
+  end
 
   if config.multiwindow then
     for _, winid in pairs(api.nvim_list_wins()) do


### PR DESCRIPTION
Commit 2bcf700b59bc92850ca83a1c02e86ba832e0fae0 breaks backward compatibility with anything below version v0.10, due to changes to LspRequest autocommand.

From [Changelog v0.10](https://neovim.io/doc/user/news-0.10.html): [LspRequest](https://neovim.io/doc/user/lsp.html#LspRequest) and LspProgressUpdate (renamed to [LspProgress](https://neovim.io/doc/user/lsp.html#LspProgress)) autocmds were promoted from [User](https://neovim.io/doc/user/autocmd.html#User) autocmds to first class citizens.