### PR TITLE
Add configuration option to set update debounce

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,6 +359,7 @@ require'treesitter-context'.setup{
   separator = nil,
   zindex = 20, -- The Z-index of the context window
   on_attach = nil, -- (fun(buf: integer): boolean) return false to disable attaching
+  update_debounce = 150, -- Rendering debounce between context updates.
 }
 ```
 

--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -10,13 +10,13 @@ local enabled = false
 --- @type table<integer, Range4[]>
 local all_contexts = {}
 
+--- @type number
+local ms = 150
+
 --- @generic F: function
 --- @param f F
---- @param ms? number
 --- @return F
-local function throttle_by_id(f, ms)
-  ms = ms or 150
-
+local function throttle_by_id(f)
   local timers = {} --- @type table<any,uv.uv_timer_t>
   local state = {} --- @type table<any,string>
   local waiting = {} --- @type table<any,boolean>
@@ -312,6 +312,8 @@ function M.setup(options)
     init()
     did_init = true
   end
+
+  ms = config.update_debounce
 end
 
 --- @param depth integer? default 1

--- a/lua/treesitter-context/config.lua
+++ b/lua/treesitter-context/config.lua
@@ -8,6 +8,7 @@
 --- @field trim_scope 'outer'|'inner'
 --- @field zindex integer
 --- @field mode 'cursor'|'topline'
+--- @field update_debounce integer
 --- @field separator? string
 --- @field on_attach? fun(buf: integer): boolean
 
@@ -38,6 +39,9 @@
 --- Line used to calculate context.
 --- @field mode? 'cursor'|'topline'
 ---
+--- Rendering deboucne between context updates.
+--- @field update_debounce? integer
+---
 --- Separator between context and content. Should be a single character string, like '-'.
 --- When separator is set, the context will only show up when there are at least 2 lines above cursorline.
 --- @field separator? string
@@ -56,6 +60,7 @@ local default_config = {
   trim_scope = 'outer',
   zindex = 20,
   mode = 'cursor',
+  update_debounce = 150,
 }
 
 local config = vim.deepcopy(default_config)


### PR DESCRIPTION
Added an option to the `setup({ ... })` function that allows the user to specify the debounce in milliseconds. This way the user can balance performance with responsiveness according to their preference.

```lua
require("treesitter-context").setup({
    update_debounce = 15,
})
```