### PR TITLE
feat(proto): add context for oneof

### DIFF
--- a/queries/proto/context.scm
+++ b/queries/proto/context.scm
@@ -2,4 +2,5 @@
   (enum)
   (message)
   (service)
+  (oneof)
 ] @context)

--- a/test/lang/test.proto
+++ b/test/lang/test.proto
@@ -5,17 +5,15 @@ package test;
 
 // {{TEST}}
 enum SomeEnum { // {{CONTEXT}}
-	UNDEFINED = 0
+  UNDEFINED = 0;
 
-	FIRST = 1
+  FIRST = 1;
 
-	SECOND = 2
+  SECOND = 2;
 
-	THIRD = 3
+  THIRD = 3;
 
-	FORTH = 4
-
-
+  FORTH = 4;
 
 
 
@@ -30,16 +28,18 @@ enum SomeEnum { // {{CONTEXT}}
 
 
 
-	FIFTH = 5
 
-	SIXTH = 6
 
-	SEVENTH = 7
+  FIFTH = 5;
 
-	EIGHTH = 8
+  SIXTH = 6;
 
-	NINTH = 9
-	// {{CURSOR}}
+  SEVENTH = 7;
+
+  EIGHTH = 8;
+
+  NINTH = 9;
+  // {{CURSOR}}
 }
 
 
@@ -56,17 +56,15 @@ message SomeMessage { // {{CONTEXT}}
 
 
 
-        optional SomeEnum someEnum = 1;
+  optional SomeEnum someEnum = 1;
 
-	optional string name = 2;
+  optional string name = 2;
 
-	optional int32 id = 3;
+  optional int32 id = 3;
 
-	optional int32 age = 4;
+  optional int32 age = 4;
 
-	optional bool isMale = 5;
-
-
+  optional bool isMale = 5;
 
 
 
@@ -76,18 +74,20 @@ message SomeMessage { // {{CONTEXT}}
 
 
 
-	optional int32 height = 6;
-
-	optional int32 weight = 7;
-
-	optional int32 score = 8;
-
-	optional int32 level = 9;
 
 
+  optional int32 height = 6;
+
+  optional int32 weight = 7;
+
+  optional int32 score = 8;
+
+  optional int32 level = 9;
 
 
-{{CURSOR}}
+
+
+  // {{CURSOR}}
 }
 
 
@@ -129,7 +129,7 @@ service SomeService { // {{CONTEXT}}
 
 
 
-	// {{CURSOR}}
+  // {{CURSOR}}
 }
 
 
@@ -144,8 +144,8 @@ service SomeService { // {{CONTEXT}}
 
 // {{TEST}}
 message SomeMessage { // {{CONTEXT}}
-	oneof someOneof { // {{CONTEXT}}
-		SomeEnum someEnum = 1;
+  oneof someOneof { // {{CONTEXT}}
+    SomeEnum someEnum = 1;
 
 
 
@@ -161,6 +161,6 @@ message SomeMessage { // {{CONTEXT}}
 
 
 
-	// {{CURSOR}}
-       }
+  // {{CURSOR}}
+  }
 }

--- a/test/lang/test.proto
+++ b/test/lang/test.proto
@@ -142,3 +142,25 @@ service SomeService { // {{CONTEXT}}
 
 
 
+// {{TEST}}
+message SomeMessage { // {{CONTEXT}}
+	oneof someOneof { // {{CONTEXT}}
+		SomeEnum someEnum = 1;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+	// {{CURSOR}}
+       }
+}


### PR DESCRIPTION
Was dealing with a large oneof and was missing the context for it. This adds the oneof as a context. Additionally, we also clean up the test proto a bit to be spaces instead of tabs, and also fix the syntax errors for the enum.
