### PR TITLE
test: support tests with different extensions than the lang name

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -7,7 +7,7 @@
       "$VIMRUNTIME",
       "${3rd}/busted/library",
       "${3rd}/luv/library",
-      "nvim-test"
+      "deps/nvim-test"
     ],
     "workspace.checkThirdParty": false,
     "diagnostics": {

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Note: support for specific languages is strictly community maintained and can br
   - [x] `devicetree`
   - [x] `diff`
   - [x] `elixir`
-  - [x] `enforce`
   - [x] `elm`
+  - [x] `enforce`
   - [x] `fennel`
   - [x] `fish`
   - [x] `fortran`

--- a/test/contexts_spec.lua
+++ b/test/contexts_spec.lua
@@ -55,69 +55,94 @@ local function parse_directives(filename)
 end
 
 local langs = get_langs()
-local langs_with_queries = {}
+local langs_with_queries = {} --- @type string[]
 for _, lang in ipairs(langs) do
   if vim.uv.fs_stat('queries/' .. lang .. '/context.scm') then
     table.insert(langs_with_queries, lang)
   end
 end
 
+local filetype_to_test_files = {} --- @type table<string,string[]>
+setup(function()
+  clear()
+  cmd([[set runtimepath+=.,./deps/nvim-treesitter]])
+
+  -- Required to load custom predicates
+  exec_lua([[require'nvim-treesitter'.setup()]])
+
+  local test_files = fn.globpath('test/lang', '*', true, true) --- @type string[]
+  for _, test_file in ipairs(test_files) do
+    cmd('edit ' .. test_file)
+    local bufnr = api.nvim_get_current_buf()
+    --- @type string
+    local filetype = exec_lua([[return vim.filetype.match({ buf = ... })]], bufnr)
+    if filetype ~= vim.NIL then
+      if not filetype_to_test_files[filetype] then
+        filetype_to_test_files[filetype] = {}
+      end
+      table.insert(filetype_to_test_files[filetype], test_file)
+    end
+  end
+end)
+
 for _, lang in ipairs(langs_with_queries) do
   describe('contexts (' .. lang .. '):', function()
-    local test_file = 'test/lang/test.' .. lang
-    if not vim.uv.fs_stat(test_file) then
+    --- @type string
+    local filetype = exec_lua(
+      [[return require('nvim-treesitter.parsers').get_parser_configs()[...].filetype]],
+      lang
+    )
+    if filetype == vim.NIL then
+      filetype = lang
+    end
+    local test_files_for_filetype = filetype_to_test_files[filetype]
+    if not test_files_for_filetype then
       pending('No test file')
       return
     end
+    for _, test_file in ipairs(test_files_for_filetype) do
+      local contexts = parse_directives(test_file)
 
-    local contexts = parse_directives(test_file)
+      if not contexts or not next(contexts) then
+        pending('No test markers in ' .. test_file)
+        return
+      end
 
-    if not contexts or not next(contexts) then
-      pending('No tests')
-      return
-    end
+      setup(function()
+        cmd([[let $XDG_CACHE_HOME='scratch/cache']])
+        install_langs(lang)
+      end)
 
-    setup(function()
-      clear()
-      cmd([[set runtimepath+=.,./deps/nvim-treesitter]])
+      for cursor_row, context_rows in pairs(contexts) do
+        it(('line %s in %s'):format(cursor_row, test_file), function()
+          cmd('edit ' .. test_file)
+          local bufnr = api.nvim_get_current_buf()
+          local winid = api.nvim_get_current_win()
+          api.nvim_win_set_cursor(winid, { cursor_row + 1, 0 })
+          assert(fn.getline('.'):match('{{CURSOR}}'))
+          feed(string.format('zt%d<C-y>', #context_rows + 2))
 
-      -- Required to load custom predicates
-      exec_lua([[require'nvim-treesitter'.setup()]])
-
-      cmd([[let $XDG_CACHE_HOME='scratch/cache']])
-
-      install_langs(lang)
-    end)
-
-    for cursor_row, context_rows in pairs(contexts) do
-      it(('line %s in %s'):format(cursor_row, test_file), function()
-        cmd('edit ' .. test_file)
-        local bufnr = api.nvim_get_current_buf()
-        local winid = api.nvim_get_current_win()
-        api.nvim_win_set_cursor(winid, { cursor_row + 1, 0 })
-        assert(fn.getline('.'):match('{{CURSOR}}'))
-        feed(string.format('zt%d<C-y>', #context_rows + 2))
-
-        --- @type [integer,integer,integer,integer][]
-        local ranges = exec_lua(
-          [[
+          --- @type [integer,integer,integer,integer][]
+          local ranges = exec_lua(
+            [[
           return require('treesitter-context.context').get(...)
         ]],
-          bufnr,
-          winid
-        )
+            bufnr,
+            winid
+          )
 
-        local act_context_rows = {} --- @type integer[]
-        for _, r in ipairs(ranges) do
-          table.insert(act_context_rows, r[1])
-        end
+          local act_context_rows = {} --- @type integer[]
+          for _, r in ipairs(ranges) do
+            table.insert(act_context_rows, r[1])
+          end
 
-        helpers.eq(
-          context_rows,
-          act_context_rows,
-          string.format('test for cursor %d failed', cursor_row)
-        )
-      end)
+          helpers.eq(
+            context_rows,
+            act_context_rows,
+            string.format('test for cursor %d failed', cursor_row)
+          )
+        end)
+      end
     end
   end)
 end


### PR DESCRIPTION
previously, we only ran tests for when the treesitter language name is
the same as the extension name, but this is not the case for many
languages. in this commit, we add support for these excluded tests. For
example, test.sol was excluded because the test searches for
test.solidity which does not exist. Now, we get all files in test/lang/*
and group them by filetype, get the filetype for each treesitter
language, and run the tests that match the filetype.

The largest motivator for this is adding starlark support, which has
files with the extension .bzl.