### PR TITLE
feat(starlark): add support

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Note: support for specific languages is strictly community maintained and can br
   - [x] `scala`
   - [x] `scss`
   - [x] `smali`
+  - [x] `starlark`
   - [x] `solidity`
   - [x] `svelte`
   - [x] `swift`
@@ -301,7 +302,6 @@ Note: support for specific languages is strictly community maintained and can br
   - [ ] `sql`
   - [ ] `squirrel`
   - [ ] `ssh_config`
-  - [ ] `starlark`
   - [ ] `strace`
   - [ ] `styled`
   - [ ] `supercollider`

--- a/queries/starlark/context.scm
+++ b/queries/starlark/context.scm
@@ -1,0 +1,26 @@
+; comment captures are not inside the body block
+(function_definition
+  (comment) @context.end
+) @context
+
+(function_definition
+  body: (_) @context.end
+) @context
+
+; comment captures are not inside the consequence block
+(if_statement
+  (comment) @context.end
+) @context
+
+(if_statement
+  consequence: (_) @context.end
+) @context
+
+(call
+  (argument_list) @context.end
+) @context
+
+([
+  (dictionary)
+  (list)
+] @context)

--- a/test/lang/test.bzl
+++ b/test/lang/test.bzl
@@ -1,0 +1,42 @@
+# {{TEST}}
+def function_definition(): # {{CONTEXT}}
+    """
+
+
+    {{CURSOR}}"""
+    if True: # {{CONTEXT}}
+
+
+
+
+        "{{CURSOR}}"
+
+# {{TEST}}
+def function_definition_2(): # {{CONTEXT}}
+    native.genrule( # {{CONTEXT}}
+        name = "genrule",
+
+
+        # {{CURSOR}}
+    )
+
+# {{TEST}}
+LIST = [ # {{CONTEXT}}
+
+
+
+    "{{CURSOR}}",
+]
+# {{TEST}}
+DICT = { # {{CONTEXT}}
+    "key": "value",
+    "dict_key": { # {{CONTEXT}}
+        "key": "value",
+        "list_key": [ # {{CONTEXT}}
+
+
+
+            "{{CURSOR}}",
+        ],
+    }
+}


### PR DESCRIPTION
includes captures for if statements, function definitions, target or
macro calls, dicts and lists. special care was taken to not include
comments inside the context block while still allowing for multiline
function and if context blocks.

relies on #565 for tests to run
