### PR TITLE
test: map treesitter lang to test file

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ Note: support for specific languages is strictly community maintained and can br
   - [x] `scala`
   - [x] `scss`
   - [x] `smali`
-  - [x] `starlark`
   - [x] `solidity`
+  - [x] `starlark`
   - [x] `svelte`
   - [x] `swift`
   - [x] `tact`


### PR DESCRIPTION
was trying to update the tests to take advantage of #565, but some of the tests were not being detected correctly. This was due to the filetype not determined by `vim.filetype.match`, but set to `vim.bo.filetype` directly. Rather than adding a separate map for the directly set filetypes, I found that I could map treesitter lang to the files it maps to directly. Beyond that, we could use a similar method in this PR to get the injected treesitter languages at cursors in a file to test those as well, but that will be for a future PR, as this one is simply to fix the regression on tests.
