### PR TITLE
fix: explicitly set border to 'none' when no separator

### DIFF
--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -73,7 +73,7 @@ local function display_window(winid, context_winid, width, height, col, ty, hl)
       style = 'minimal',
       noautocmd = true,
       zindex = config.zindex,
-      border = sep and { '', '', '', '', sep, sep, sep, '' } or nil,
+      border = sep and { '', '', '', '', sep, sep, sep, '' } or 'none',
     })
     vim.w[context_winid][ty] = true
     vim.wo[context_winid].wrap = false


### PR DESCRIPTION
This prevents a messy look if `vim.o.winborder` is changed to any type other than "none".

Context:

As of [this recently merged PR](https://github.com/neovim/neovim/pull/31074) neovim now has an option to set a default winborder. This can cause some unexpected behavior in plugins that assume the default to be "none".

This PR explicitly sets the border to `"none"` rather than `nil` so that if the user runs `:set winborder=rounded` or similar it won't cause rounded borders on the treesitter-context display.

Example without this fix:
![image](https://github.com/user-attachments/assets/5c82c946-4774-4820-bd9f-781bd7700dee)
