### PR TITLE
test: properly check treesitter lang and only install parser when needed

### DIFF
--- a/test/contexts_spec.lua
+++ b/test/contexts_spec.lua
@@ -77,11 +77,7 @@ setup(function()
     --- @type string
     local treesitter_lang = exec_lua(
       [[
-    local ok, parser = pcall(vim.treesitter.get_parser, ...)
-    if not ok then
-      return nil
-    end
-    return parser:lang()
+    return require('nvim-treesitter.parsers').get_buf_lang(...)
     ]],
       bufnr
     )
@@ -111,7 +107,7 @@ for _, lang in ipairs(langs_with_queries) do
         return
       end
 
-      setup(function()
+      lazy_setup(function()
         cmd([[let $XDG_CACHE_HOME='scratch/cache']])
         install_langs(lang)
       end)


### PR DESCRIPTION
Because of the way we were checking the treesitter lang, we were relying
on the parser to already be installed for the test to not be skipped.
Now we check it via an `nvim-treesitter` API that does not require the
parser to be installed. This results in all the parsers to be installed
even when the related tests won't be run, so we do a lazy setup here as
well.

Followup to #568
