### PR TITLE
test: support injected query tests

### DIFF
--- a/test/lang/test.html
+++ b/test/lang/test.html
@@ -48,7 +48,7 @@
 
 
 
-      color: red; /* BUG: cannot test for injected lang here */
+      color: red; /* {{CURSOR}} */
 
 
 
@@ -133,8 +133,14 @@
 
 
     var b = 2;
-    function test() {
+    function test() { // {{CONTEXT}}
       let test = "asdasd";
+
+
+
+
+
+      // {{CURSOR}}
     }
 
     var c = a + b;

--- a/test/lang/test.md
+++ b/test/lang/test.md
@@ -1,27 +1,13 @@
-```html
-<html>
-  <body>
+```html <!-- {{CONTEXT}} -->
+<html> <!-- {{CONTEXT}} -->
+  <body> <!-- {{CONTEXT}} -->
 
 
 
 
 
 
-    <script>
-
-
-
-
-
-
-
-
-
-
-
-
-      function test() {
-        if test != "" {
+    <script> <!-- {{CONTEXT}} -->
 
 
 
@@ -34,16 +20,30 @@
 
 
 
+      function test() { // {{CONTEXT}}
+        if test != "" { // {{CONTEXT}}
 
 
 
+
+
+
+
+
+
+
+
+
+
+
+          // {{CURSOR}}
         }
       }
     </script>
   </body>
 </html>
 ```
-
+{{TEST}}
 # Title {{CONTEXT}}
 
 


### PR DESCRIPTION
The `context_spec.lua` tests do not cover test files that have injected queries. To cover these, we recursively parse the file to get the injected languages parsed, which then can be used later for the context tests. This PR also includes updating the html and markdown test files to take advantage of this capability.

Followup to #568
