### PR TITLE
test: add support for marking all visible context lines

### DIFF
--- a/test/contexts_spec.lua
+++ b/test/contexts_spec.lua
@@ -136,7 +136,11 @@ for _, lang in ipairs(langs_with_queries) do
 
           local act_context_rows = {} --- @type integer[]
           for _, r in ipairs(ranges) do
-            table.insert(act_context_rows, r[1])
+            local start_row = r[1]
+            local end_row = r[3]
+            for i = start_row, end_row - 1 do
+              table.insert(act_context_rows, i)
+            end
           end
 
           helpers.eq(

--- a/test/lang/test.adb
+++ b/test/lang/test.adb
@@ -64,7 +64,7 @@ end Show_Increment;
 
 -- {{TEST}}
 type Date is -- {{CONTEXT}}
-  record
+  record -- {{CONTEXT}}
   Day : Integer range 1 .. 31;
 
   Month : Months := Jan;

--- a/test/lang/test.c
+++ b/test/lang/test.c
@@ -21,19 +21,27 @@ typedef enum { // {{CONTEXT}}
 // {{TEST}}
 
 int main(int arg1, // {{CONTEXT}}
-         char **arg2,
-         char **arg3)
-{
+         char **arg2, // {{CONTEXT}}
+         char **arg3) // {{CONTEXT}}
+{ // {{CONTEXT}}
 
   if (arg1 == 4 // {{CONTEXT}}
-      && arg2 == arg3) {
+      && arg2 == arg3) { // {{CONTEXT}}
+
+
+
 
     // {{CURSOR}}
 
     for (int i = 0; i < arg1; i++) { // {{CONTEXT}}
 
+
+
+
       // {{CURSOR}}
       while (1) { // {{CONTEXT}}
+
+
 
 
         // {{CURSOR}}

--- a/test/lang/test.cpp
+++ b/test/lang/test.cpp
@@ -51,12 +51,12 @@ typedef enum { // {{CONTEXT}}
 
 // {{TEST}}
 int main(int arg1, // {{CONTEXT}}
-         char **arg2, // BUG: marking context here does not work
-         char **arg3
-         )
-{
+         char **arg2, // {{CONTEXT}}
+         char **arg3 // {{CONTEXT}}
+         ) // {{CONTEXT}}
+{ // {{CONTEXT}}
   if (arg1 == 4 // {{CONTEXT}}
-      && arg2 == arg3) {
+      && arg2 == arg3) { // {{CONTEXT}}
     for (int i = 0; i < arg1; i++) { // {{CONTEXT}}
       while (1) { // {{CONTEXT}}
 
@@ -71,7 +71,7 @@ int main(int arg1, // {{CONTEXT}}
   // {{POPCONTEXT}}
   // {{POPCONTEXT}}
   // {{POPCONTEXT}}
-
+  // {{POPCONTEXT}}
 
 
   do { // {{CONTEXT}}

--- a/test/lang/test.css
+++ b/test/lang/test.css
@@ -23,7 +23,7 @@
     } /* {{POPCONTEXT}} */
 
     @color-profile /* {{CONTEXT}} */
-    --swop5c { /* BUG: marking context here does not work */
+    --swop5c { /* {{CONTEXT}} */
 
 
 
@@ -37,7 +37,7 @@
         /* {{CURSOR}} */
 
     } /* {{POPCONTEXT}} */
-
+    /* {{POPCONTEXT}} */
 
 
 
@@ -80,14 +80,16 @@
 
 /* {{TEST}} */
 @media ( /* {{CONTEXT}} */
+/* {{CONTEXT}} */
+prefers-reduced-motion: reduce) { /* {{CONTEXT}} */
 
-prefers-reduced-motion: reduce) {
+
 
 
   /* {{CURSOR}} */
   *, /* {{CONTEXT}} */
-  *::before,
-  *::after {
+  *::before, /* {{CONTEXT}} */
+  *::after { /* {{CONTEXT}} */
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
@@ -109,8 +111,8 @@ prefers-reduced-motion: reduce) {
     /* {{CURSOR}} */
 
   } /* {{POPCONTEXT}} */
-
-
+  /* {{POPCONTEXT}} */
+  /* {{POPCONTEXT}} */
 
 
 

--- a/test/lang/test.cu
+++ b/test/lang/test.cu
@@ -58,12 +58,12 @@ __global__ void kernel(int *a, int *b, int *c) { // {{CONTEXT}}
 
 // {{TEST}}
 int main(int arg1, // {{CONTEXT}}
-         char **arg2,
-         char **arg3
-         )
-{
+         char **arg2, // {{CONTEXT}}
+         char **arg3 // {{CONTEXT}}
+         ) // {{CONTEXT}}
+{ // {{CONTEXT}}
   if (arg1 == 4 // {{CONTEXT}}
-      && arg2 == arg3) {
+      && arg2 == arg3) { // {{CONTEXT}}
     for (int i = 0; i < arg1; i++) { // {{CONTEXT}}
       while (1) { // {{CONTEXT}}
 
@@ -75,7 +75,7 @@ int main(int arg1, // {{CONTEXT}}
       } // {{POPCONTEXT}}
     } // {{POPCONTEXT}}
   } // {{POPCONTEXT}}
-
+  // {{POPCONTEXT}}
 
 
 

--- a/test/lang/test.d
+++ b/test/lang/test.d
@@ -1,6 +1,6 @@
 // {{TEST}}
 struct S // {{CONTEXT}}
-{
+{ // {{CONTEXT}}
 
 
 
@@ -31,7 +31,7 @@ enum Things { // {{CONTEXT}}
 }
 // {{TEST}}
 union U // {{CONTEXT}}
-{
+{ // {{CONTEXT}}
     ubyte i;
 
 
@@ -41,7 +41,7 @@ union U // {{CONTEXT}}
 }
 // {{TEST}}
 interface Bar // {{CONTEXT}}
-{
+{ // {{CONTEXT}}
 
 
 
@@ -49,14 +49,14 @@ interface Bar // {{CONTEXT}}
 }
 // {{TEST}}
 class Foo : Bar // {{CONTEXT}}
-{
+{ // {{CONTEXT}}
 
 
 
     // {{CURSOR}}
     void bar (int a, // {{CONTEXT}}
-        int b)
-    {
+        int b) // {{CONTEXT}}
+    { // {{CONTEXT}}
 
     try { // {{CONTEXT}}
 

--- a/test/lang/test.dart
+++ b/test/lang/test.dart
@@ -1,9 +1,9 @@
 // {{TEST}}
 @Deprecated('') // {{CONTEXT}}
-abstract // BUG: there should be context here
-class User 
-    extends 
-      Object {
+abstract // {{CONTEXT}}
+class User // {{CONTEXT}}
+    extends // {{CONTEXT}}
+      Object { // {{CONTEXT}}
   User(this.age);
   int age;
 
@@ -40,19 +40,19 @@ class User
 // {{TEST}}
 String(
   int magicalNumber,
-) { // {{CONTEXT}
+) { // {{CONTEXT}}
   if (magicalNumber == "69" // {{CONTEXT}}
-      // --
-      ||
-      magicalNumber == "420") {
+      // {{CONTEXT}}
+      || // {{CONTEXT}}
+      magicalNumber == "420") { // {{CONTEXT}}
     return 'pretty nice';
 
 
 
     // {{CURSOR}}
   } else if (magicalNumber == "420" // {{CONTEXT}}
-      &&
-      magicalNumber == "69") {
+      && // {{CONTEXT}}
+      magicalNumber == "69") { // {{CONTEXT}}
 
 
 
@@ -84,7 +84,7 @@ String(
 // {{TEST}}
 void catching() { // {{CONTEXT}}
   try // {{CONTEXT}}
-    // --
+    // {{CONTEXT}}
   {
 
 
@@ -129,8 +129,8 @@ void catching() { // {{CONTEXT}}
 // {{TEST}}
 void foring() { // {{CONTEXT}}
   for (int i = 0; // {{CONTEXT}}
-        i < 10;
-        i++) {
+        i < 10; // {{CONTEXT}}
+        i++) { // {{CONTEXT}}
 
 
 
@@ -146,9 +146,11 @@ void foring() { // {{CONTEXT}}
 
     // {{CURSOR}}
   } // {{POPCONTEXT}}
+  // {{POPCONTEXT}}
+  // {{POPCONTEXT}}
 
   while (true // {{CONTEXT}}
-  == false) {
+  == false) { // {{CONTEXT}}
 
 
 
@@ -168,6 +170,7 @@ void foring() { // {{CONTEXT}}
     // {{CURSOR}}
 
 } // {{POPCONTEXT}}
+// {{POPCONTEXT}}
 
   do { // {{CONTEXT}}
 
@@ -188,7 +191,7 @@ void foring() { // {{CONTEXT}}
 }
 // {{TEST}}
 extension ext // {{CONTEXT}}
-on int {
+on int { // {{CONTEXT}}
 
 
 

--- a/test/lang/test.f90
+++ b/test/lang/test.f90
@@ -1,12 +1,12 @@
 ! {{TEST}}
 program ! {{CONTEXT}}
-    foo
+    foo ! {{CONTEXT}}
 
 
 
     ! {{CURSOR}}
     type ! {{CONTEXT}}
-        eigensys_t
+        eigensys_t ! {{CONTEXT}}
 
         real(idp) :: bar1(:,:)
 
@@ -14,9 +14,10 @@ program ! {{CONTEXT}}
 
         integer    :: n ! {{CURSOR}}
     end type eigensys_t ! {{POPCONTEXT}}
+    ! {{POPCONTEXT}}
 
     do i = 1, ! {{CONTEXT}}
-        eigensystem%n
+        eigensystem%n ! {{CONTEXT}}
 
         write(*,'(" Eigenvector ",I1,": ")') i
 
@@ -25,20 +26,20 @@ program ! {{CONTEXT}}
     end do ! {{POPCONTEXT}}
 
     contains
-    subroutine aaaaaaaa(foo, ! {{CONTEXT}}
+    subroutine aaaaaaaa(foo,
         bar)
 
-        if ( ! {{CONTEXT}}
+        if (
             foo /= 0) then
 
 
-            ! {{CURSOR}}
+
         else if (
             foo /= 1) then
 
 
             foo = foo + 1
-        else ! {{CONTEXT}}
+        else
 
             ! BUG: cannot mark cursor here
             bar = 2

--- a/test/lang/test.go
+++ b/test/lang/test.go
@@ -12,12 +12,12 @@ import ( // {{CONTEXT}}
 // {{TEST}}
 
 func (r *rect) area(a int, // {{CONTEXT}}
-b int) int {
+b int) int { // {{CONTEXT}}
     return r.width * r.height
 
+
+
 // {{CURSOR}}
-
-
 }
 
 var b
@@ -27,8 +27,8 @@ var b
 // {{TEST}}
 
 func foo(a int, // {{CONTEXT}}
-  b int) (int,
-  int) {
+  b int) (int, // {{CONTEXT}}
+  int) { // {{CONTEXT}}
 
     i := 1
 
@@ -38,9 +38,9 @@ func foo(a int, // {{CONTEXT}}
     case msg2 := <-c2: // {{CONTEXT}}
 
 
+
+
       // {{CURSOR}}
-
-
       fmt.Println("received", msg2)
   }
 

--- a/test/lang/test.graphql
+++ b/test/lang/test.graphql
@@ -1,7 +1,7 @@
 # {{TEST}}
 interface # {{CONTEXT}}
-  Foo
-{
+  Foo # {{CONTEXT}}
+{ # {{CONTEXT}}
   id: ID!
   name: String
 
@@ -9,14 +9,16 @@ interface # {{CONTEXT}}
 }
 # {{TEST}}
 input # {{CONTEXT}}
-  Stuff {
+  Stuff { # {{CONTEXT}}
   limit: Int
   since_id: ID
+
+
   # {{CURSOR}}
 }
 # {{TEST}}
 type Bar # {{CONTEXT}}
-  implements Foo {
+  implements Foo { # {{CONTEXT}}
   age: Int
 
 
@@ -63,9 +65,9 @@ query GetSearchResults { # {{CONTEXT}}
 }
 # {{TEST}}
 mutation # {{CONTEXT}}
-  CreateBar {
+  CreateBar { # {{CONTEXT}}
   addBar(name: "AAAA", # {{CONTEXT}}
-    age: 42) {
+    age: 42) { # {{CONTEXT}}
     name
     foo {
       age

--- a/test/lang/test.java
+++ b/test/lang/test.java
@@ -4,15 +4,15 @@ import stuff1;
 import stuff2;
 
 @class_annot_1 // {{CONTEXT}}
-@class_annot_2
-public class MyClass {
+@class_annot_2 // {{CONTEXT}}
+public class MyClass { // {{CONTEXT}}
 
 
 
     // {{CURSOR}}
     @method_annot_1 // {{CONTEXT}}
-    @method_annot_2
-    public void my_method(int param) {
+    @method_annot_2 // {{CONTEXT}}
+    public void my_method(int param) { // {{CONTEXT}}
 
 
 

--- a/test/lang/test.jl
+++ b/test/lang/test.jl
@@ -15,13 +15,13 @@ struct Foo{T} # {{CONTEXT}}
 end
 # {{TEST}}
 function myfunc( # {{CONTEXT}}
-    x::Vector,
-    y::Int,
-)
+    x::Vector, # {{CONTEXT}}
+    y::Int, # {{CONTEXT}}
+) # {{CONTEXT}}
     @assert y > 0
     for i in 1:y # {{CONTEXT}}
         if i == 0 && # {{CONTEXT}}
-           i == 0 # Unnecessary condition to go over 2 lines.
+            i == 0 # {{CONTEXT}}
             println("zero")
             # comment
             # comment
@@ -43,6 +43,7 @@ function myfunc( # {{CONTEXT}}
             # comment
             # {{CURSOR}}
         end # {{POPCONTEXT}}
+        # {{POPCONTEXT}}
     end # {{POPCONTEXT}}
     # comment
     # comment
@@ -51,7 +52,7 @@ function myfunc( # {{CONTEXT}}
     # {{CURSOR}}
     foo = y
     while foo > 0 && # {{CONTEXT}}
-        foo > 0 # Unnecessary condition to go over 2 lines.
+        foo > 0 # {{CONTEXT}}
         println(foo)
         foo -= 1
         # comment
@@ -60,7 +61,7 @@ function myfunc( # {{CONTEXT}}
         # comment
         # {{CURSOR}}
     end # {{POPCONTEXT}}
-    # comment
+    # {{POPCONTEXT}}
     # comment
     # comment
     # comment

--- a/test/lang/test.m
+++ b/test/lang/test.m
@@ -1,10 +1,13 @@
 % {{TEST}}
 if x < 0 && % {{CONTEXT}}
-  y < 0
+  y < 0 % {{CONTEXT}}
+
 
 
   y = 0; % {{CURSOR}}
 elseif x < 1 % {{CONTEXT}}
+
+
 
 
   y = x; % {{CURSOR}}
@@ -12,8 +15,9 @@ elseif x < 1 % {{CONTEXT}}
 else % {{CONTEXT}}
 
 
+
   y = 1; % {{CURSOR}}
-end % {{POPCONTEXT}}
+end
 
 % {{TEST}}
 while x < 5 % {{CONTEXT}}
@@ -54,15 +58,18 @@ end % {{POPCONTEXT}}
 
 % {{TEST}}
 function [C] = myMatMult(A, % {{CONTEXT}}
-  B)
+  B) % {{CONTEXT}}
     [m,n] = size(A);
     [p,q] = size(B);
     if n ~= % {{CONTEXT}}
-      p
+      p % {{CONTEXT}}
         error('Inner matrix dimensions must agree.');
+
+
 
       % {{CURSOR}}
     end % {{POPCONTEXT}}
+    % {{POPCONTEXT}}
     C = zeros(m,q); % {{CURSOR}}
     for i =
       1:m

--- a/test/lang/test.nix
+++ b/test/lang/test.nix
@@ -1,20 +1,22 @@
 
 {
   output = # {{CONTEXT}}
- 
-
-
-
-
-
-
-
-    # {{CURSOR}}
-   let
-      l = {
+    # {{CONTEXT}}
+    # {{CONTEXT}}
+    # {{CONTEXT}}
+    # {{CONTEXT}}
+    # {{CONTEXT}}
+    # {{CONTEXT}}
+    # {{CONTEXT}}
+    # {{CONTEXT}}
+    # {{CONTEXT}}
+   let # {{CONTEXT}}
+      l = { # {{CONTEXT}}
         a = false;
         b = false;
         c = false;
+
+        # {{CURSOR}}
       }; #Succe
       m = {
         a = false;

--- a/test/lang/test.prisma
+++ b/test/lang/test.prisma
@@ -15,7 +15,7 @@ client {
 }
 
 enum // {{CONTEXT}}
-Role {
+Role { // {{CONTEXT}}
 
   USER
 

--- a/test/lang/test.rb
+++ b/test/lang/test.rb
@@ -1,13 +1,13 @@
 # frozen_string_literal: true
 
-module Bar
+module Bar # BUG: The contexts here include too many newlines
   class Foo
     class << self
-      def run # {{CONTEXT}}
+      def run
 
 
 
-        # {{CURSOR}}
+
         if false
           (20..30).each do |element|
             block.call(element)
@@ -40,11 +40,15 @@ module Bar
   end
 end
 
-RSpec.describe 'foo' do
-  context 'bar' do
-    shared_context 'shared context' do
-      it 'test' do
-        expect(1).to eq(1)
+RSpec.describe 'foo' do # {{CONTEXT}}
+  context 'bar' do # {{CONTEXT}}
+    shared_context 'shared context' do # {{CONTEXT}}
+      it 'test' do # {{CONTEXT}}
+
+
+
+
+        expect(1).to eq(1) # {{CURSOR}}
       end
     end
 

--- a/test/lang/test.smali
+++ b/test/lang/test.smali
@@ -1,4 +1,4 @@
-.class public Lbaksmali/test/class;
+.class public Lbaksmali/test/class; # BUG: The contexts here are extremely buggy and include too many newlines
 .super Ljava/lang/Object;
 
 .source "baksmali_test_class.smali"
@@ -85,7 +85,7 @@
     return-void
 .end method
 
-.method public testMethod(ILjava/lang/String;)Ljava/lang/String; # {{CONTEXT}}
+.method public testMethod(ILjava/lang/String;)Ljava/lang/String;
     .registers 3
     .annotation runtime Lorg/junit/Test;
     .end annotation
@@ -96,7 +96,7 @@
 
 	const-string v0, "testing\n123"
 
-	goto switch: # {{CURSOR}}
+	goto switch:
 
 	sget v0, Lbaksmali/test/class;->staticField:I
 

--- a/test/lang/test.swift
+++ b/test/lang/test.swift
@@ -6,7 +6,7 @@ var list = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 switch i { // {{CONTEXT}}
 
 case let x // {{CONTEXT}}
-where x > 0:
+where x > 0: // {{CONTEXT}}
 
 
 


### PR DESCRIPTION
This enforces that all visible lines in the context are labeled within the test. This reveals a few tests where the context queries are poor and are capturing whitespace, and also allows for finer granularity of testing within the test files. The out of date files have new context tests as a result.
