### PR TITLE
refactor: expose context window

### DIFF
--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -481,6 +481,7 @@ end
 --- @param winid integer
 --- @param ctx_ranges Range4[]
 --- @param ctx_lines string[]
+--- @return WindowContext?
 function M.open(bufnr, winid, ctx_ranges, ctx_lines)
   local gutter_width = get_gutter_width(winid)
   local win_width = math.max(1, api.nvim_win_get_width(winid) - gutter_width)
@@ -527,7 +528,7 @@ function M.open(bufnr, winid, ctx_ranges, ctx_lines)
 
   if not set_lines(ctx_bufnr, ctx_lines) then
     -- Context didn't change, can return here
-    return
+    return window_context
   end
 
   api.nvim_buf_clear_namespace(ctx_bufnr, -1, 0, -1)
@@ -535,6 +536,7 @@ function M.open(bufnr, winid, ctx_ranges, ctx_lines)
   copy_extmarks(bufnr, ctx_bufnr, ctx_ranges)
   highlight_bottom(ctx_bufnr, win_height - 1, 'TreesitterContextBottom')
   horizontal_scroll_contexts(winid, window_context.context_winid)
+  return window_context
 end
 
 --- @param winid? integer


### PR DESCRIPTION
## Problem
To attach `treesitter-context` on a float window, we need to create context with a larger `zindex` than the float window.

However there's no way to properly achieve it, since all context win use the same `config.zindex`.
(so larger `config.zindex` cause float window overlap with the context attached on non-float window)

![image](https://github.com/user-attachments/assets/ba6266a0-c569-4f80-bc10-623258f6effd)

## Solution
~Make `render.open` accept an `win_config`. (But I'm not sure if this will increase maintain burden here).~

Another way is expose `context_winid`, so we can fix `zindex` later by `nvim_win_set_config`.

(A downstream fix https://github.com/ibhagwan/fzf-lua/pull/2023 via this)