### PR TITLE
fix: ignore win_col virt_text_pos value when copying extmarks

### DIFF
--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -419,6 +419,11 @@ local function copy_extmarks(bufnr, ctx_bufnr, contexts)
         end_row = offset + (mend_row - ctx_srow)
       end
 
+      local virt_text_pos = opts.virt_text_pos
+      if virt_text_pos == 'win_col' then
+        virt_text_pos = nil
+      end
+
       -- Use pcall incase fields from opts are inconsistent with opts in
       -- nvim_buf_set_extmark
       pcall(add_extmark, ctx_bufnr, start_row, col, {
@@ -433,7 +438,7 @@ local function copy_extmarks(bufnr, ctx_bufnr, contexts)
         hl_eol = opts.hl_eol,
         virt_text = opts.virt_text,
         virt_text_hide = opts.virt_text_hide,
-        virt_text_pos = opts.virt_text_pos,
+        virt_text_pos = virt_text_pos,
         virt_text_repeat_linebreak = opts.virt_text_repeat_linebreak,
         virt_text_win_col = opts.virt_text_win_col,
         hl_mode = opts.hl_mode,


### PR DESCRIPTION
When setting extmarks the win_col virt_text_pos value is invalid, however it is returned in details whenever an extmark is created with some virt_text_win_col. Handle this case by setting the value to nil.

If this was intentional to avoid some issues with using virt_text_win_col in the context, then understandable, just wasn't sure.

Tested it locally using [my plugin](https://github.com/MeanderingProgrammer/render-markdown.nvim) which uses virt_text_win_col extmarks when showing headings in markdown:

| Original Mark | Context Before | Context After |
| ------------- | --------------- | ------------- |
| ![start](https://github.com/user-attachments/assets/fce33d9b-7807-479b-8e3c-4db1c5de0eb6) | ![before](https://github.com/user-attachments/assets/826361e4-0c07-439a-9997-d7457a0ea265) |  ![after](https://github.com/user-attachments/assets/7d007d11-b4df-4415-bdda-82d261cc6c20) |

The extmark using virt_text_win_col is what keeps the background from extending the entire width of the window.

Can create a minimal repro if that would be helpful.