### PR TITLE
feat(config): max_lines accept % win.height

### DIFF
--- a/doc/nvim-treesitter-context.txt
+++ b/doc/nvim-treesitter-context.txt
@@ -27,6 +27,7 @@ not required.
       multiwindow = false,
 
       -- How many lines the window should span. Values <= 0 mean no limit.
+      -- Can be '<int>%' like '30%' - to specify percentage of win.height
       max_lines = 0,
 
       -- Minimum editor window height to enable context. Values <= 0 mean no

--- a/lua/treesitter-context/config.lua
+++ b/lua/treesitter-context/config.lua
@@ -1,7 +1,7 @@
 --- @class (exact) TSContext.Config
 --- @field enable boolean
 --- @field multiwindow boolean
---- @field max_lines integer
+--- @field max_lines integer | string
 --- @field min_window_height integer
 --- @field line_numbers boolean
 --- @field multiline_threshold integer
@@ -20,7 +20,8 @@
 --- @field multiwindow? boolean
 ---
 --- How many lines the window should span. Values <= 0 mean no limit.
---- @field max_lines? integer
+--- Can be '<int>%' like '30%' - to specify percentage of win.height.
+--- @field max_lines? integer | string
 ---
 --- Minimum editor window height to enable context. Values <= 0 mean no limit.
 --- @field min_window_height? integer

--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -46,9 +46,28 @@ local function get_parent_nodes(langtree, range)
 end
 
 --- @param winid integer
+--- @param percent string
+--- @return integer
+local function max_lines_from_string(winid, percent)
+  local win_height = api.nvim_win_get_height(winid)
+  local percent_s = percent:match('^(%d+)%%$')
+  local percent = percent_s and tonumber(percent_s, 10) or 0
+  return math.ceil((percent / 100.0) * win_height)
+end
+
+--- @param winid integer
 --- @return integer
 local function calc_max_lines(winid)
-  local max_lines = config.max_lines == 0 and -1 or config.max_lines
+  local max_lines --- @type integer
+
+  if type(config.max_lines) == 'string' then
+    max_lines = max_lines_from_string(winid, config.max_lines)
+  else
+    max_lines = config.max_lines --- @type integer
+  end
+
+  -- ensure we never have zero as max lines
+  max_lines = max_lines == 0 and -1 or max_lines
 
   local wintop = fn.line('w0', winid)
   local cursor = fn.line('.', winid)


### PR DESCRIPTION
I liked the original idea, saw that it had not been implemented, so here goes a quick attempt at it.

It accepts any "<integer>%". The emmy types have also been updated, and so has the documentation. If the string is malformed it defaults to behaving as if `0` "no-limit" is supplied.