### PR TITLE
fix: do not show context when within window

### DIFF
--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -396,6 +396,14 @@ function M.get(bufnr, winid)
     end
   end
 
+  -- Do not show the context window if all contexts are below the top row.
+  local all_contexts_below_top_row =
+    not vim.tbl_contains(context_ranges, function(range) --- @param range Range4
+      return range[1] < top_row
+    end, { predicate = true })
+  if all_contexts_below_top_row then
+    return
+  end
   local trim = contexts_height - max_lines
   if trim > 0 then
     trim_contexts(context_ranges, context_lines, trim, config.trim_scope == 'outer')


### PR DESCRIPTION
Having an issue where the context shows up when the first line of the context is already in the window. This results in a case where I open a buffer and the second line is obfuscated by the separator. This fixes it in a somewhat hacky way by doing a check of the context lines to see if they are all already on the screen. I thought for a bit if I should try to fix this somewhere else, but there are a lot of edge cases and this seemed easiest/less risky.
