### PR TITLE
refactor: general tidy up

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: leafo/gh-actions-lua@v10
+      - uses: leafo/gh-actions-lua@v11
         with:
           luaVersion: "5.1.5"
 

--- a/lua/treesitter-context/config.lua
+++ b/lua/treesitter-context/config.lua
@@ -68,11 +68,10 @@ function M.update(cfg)
   config = vim.tbl_deep_extend('force', config, cfg)
 end
 
---- @type TSContext.Config
 setmetatable(M, {
   __index = function(_, k)
     return config[k]
   end,
 })
 
-return M
+return M --[[@as TSContext.Config]]

--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -51,19 +51,17 @@ end
 local function max_lines_from_string(winid, percent)
   local win_height = api.nvim_win_get_height(winid)
   local percent_s = percent:match('^(%d+)%%$')
-  local percent = percent_s and tonumber(percent_s, 10) or 0
-  return math.ceil((percent / 100.0) * win_height)
+  local percent1 = percent_s and tonumber(percent_s, 10) or 0
+  return math.ceil((percent1 / 100) * win_height)
 end
 
 --- @param winid integer
 --- @return integer
 local function calc_max_lines(winid)
-  local max_lines --- @type integer
+  local max_lines = config.max_lines
 
-  if type(config.max_lines) == 'string' then
-    max_lines = max_lines_from_string(winid, config.max_lines)
-  else
-    max_lines = config.max_lines --- @type integer
+  if type(max_lines) == 'string' then
+    max_lines = max_lines_from_string(winid, max_lines)
   end
 
   -- ensure we never have zero as max lines


### PR DESCRIPTION
- Remove `getcmdwintype()` check in Render.close().

  Check is already done in `close()` which was added with
  multiwindow support. Should no longer be needed higher
  up.

- Combine `Render.close_other_contexts()` and
  `Render.close_leaked_contexts()` into
  `Render.close_contexts()`.

- Remove unnecessary tables in `is_after()`.

- Inline `delete_excess_buffers()`.

- Collapse some code.

- Rename `update_single_context()` to `update_win()`.

- Fix typing of config module.