### PR TITLE
refactor: make `go_to_context()` get contexts directly

### DIFF
--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -312,10 +312,12 @@ local function range_is_valid(range)
   return true
 end
 
---- @param bufnr integer
---- @param winid integer
+--- @param winid? integer
 --- @return Range4[]?, string[]?
-function M.get(bufnr, winid)
+function M.get(winid)
+  winid = winid or api.nvim_get_current_win()
+  local bufnr = api.nvim_win_get_buf(winid)
+
   -- vim.treesitter.get_parser() calls bufload(), but we don't actually want to load the buffer:
   -- this method is called during plugin init, before other plugins or the user's config
   -- have a chance to initialize.

--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -449,11 +449,11 @@ end
 
 local M = {}
 
---- @param bufnr integer
 --- @param winid integer
 --- @param ctx_ranges Range4[]
 --- @param ctx_lines string[]
-function M.open(bufnr, winid, ctx_ranges, ctx_lines)
+function M.open(winid, ctx_ranges, ctx_lines)
+  local bufnr = api.nvim_win_get_buf(winid)
   local gutter_width = get_gutter_width(winid)
   local win_width = math.max(1, api.nvim_win_get_width(winid) - gutter_width)
 

--- a/test/contexts_spec.lua
+++ b/test/contexts_spec.lua
@@ -176,20 +176,15 @@ for _, lang in ipairs(langs_with_queries) do
       for cursor_row, context_rows in pairs(contexts) do
         it(('line %s in %s'):format(cursor_row, test_file), function()
           cmd('edit ' .. test_file)
-          local bufnr = api.nvim_get_current_buf()
           local winid = api.nvim_get_current_win()
           api.nvim_win_set_cursor(winid, { cursor_row + 1, 0 })
           assert(fn.getline('.'):match('{{CURSOR}}'))
           feed(string.format('zt%d<C-y>', #context_rows + 2))
 
           --- @type [integer,integer,integer,integer][]
-          local ranges = exec_lua(
-            [[
-          return require('treesitter-context.context').get(...)
-        ]],
-            bufnr,
-            winid
-          )
+          local ranges = exec_lua(function(...)
+            return assert(require('treesitter-context.context').get(...))
+          end, winid)
 
           local act_context_rows = {} --- @type integer[]
           for _, r in ipairs(ranges) do


### PR DESCRIPTION
- Removes the need for the internal `all_contexts` variable.
- Remove `bufnr` argument from `Context.get()` and make `winid`
  optional.