### PR TITLE
fix(render): ensure buffer is modifiable before rendering

### DIFF
--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -312,7 +312,9 @@ local function set_lines(bufnr, lines)
   end
 
   if redraw then
+    vim.bo[bufnr].modifiable = true
     api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+    vim.bo[bufnr].modifiable = false
     vim.bo[bufnr].modified = false
   end
 


### PR DESCRIPTION
Fix a rendering crash that occurs when starting nvim with `-c "set nomodifiable"`.

This is essentially the same issue as described in https://github.com/Saghen/blink.cmp/issues/1889
