### PR TITLE
fix: call setup in plugin directory

### DIFF
--- a/plugin/treesitter-context.lua
+++ b/plugin/treesitter-context.lua
@@ -1,3 +1,5 @@
+require('treesitter-context').setup()
+
 vim.api.nvim_create_user_command('TSContext', function(args)
   require('treesitter-context.cli').run(args.fargs)
 end, {


### PR DESCRIPTION
Fixes #620

Adds back the call to setup removed in https://github.com/nvim-treesitter/nvim-treesitter-context/commit/4cc55022cd159ec69ceda06e425af603603f3d01, which made calling `setup` mandatory.