### PR TITLE
feat(rust): add let = block context

### DIFF
--- a/queries/rust/context.scm
+++ b/queries/rust/context.scm
@@ -115,3 +115,8 @@
 (macro_definition
   name: (_) @context.end
 ) @context
+
+; let = {}
+(let_declaration
+  value: (block (_) @context.end)
+) @context

--- a/test/lang/test.rs
+++ b/test/lang/test.rs
@@ -218,3 +218,23 @@ union Bar {
     c: u32,
 
 }
+
+// {{TEST}}
+fn letblock() { // {{CONTEXT}}
+
+    let _foo = { // {{CONTEXT}}
+
+
+
+
+
+
+
+
+
+
+
+        // {{CURSOR}}
+    }
+
+}


### PR DESCRIPTION
Adding rusts variable to block binding as a context