### PR TITLE
fix(nu): remove `ctrl_do`

### DIFF
--- a/queries/nu/context.scm
+++ b/queries/nu/context.scm
@@ -32,10 +32,6 @@
   (_) @context.end
 ) @context
 
-(ctrl_do
-  (_) @context.end
-) @context
-
 (match_arm) @context
 (pipe_element) @context
 (block) @context


### PR DESCRIPTION
`ctrl_do` was removed from the nushell parser in nushell/tree-sitter-nu@7e7de17fd077a9bf490400a19110279168d5a33a