### PR TITLE
add callback for do_clause in julia

### DIFF
--- a/queries/julia/context.scm
+++ b/queries/julia/context.scm
@@ -12,3 +12,5 @@
   condition: (_) @context.final) @context
 
 (try_statement) @context
+
+(do_clause) @context


### PR DESCRIPTION
the do_clause is a multiline anonymous function which gets passed as the first argument of another function. it's basically like a function_definition, except you don't give it a name. see e.g. [do clause in REPL source](https://github.com/JuliaLang/julia/blob/7d591fcb00cafb2f0c7b2fe7f240bdfb6299b811/stdlib/REPL/src/docview.jl#L534-L564)