### PR TITLE
fix: attach when filetype has been set

### DIFF
--- a/lua/treesitter-context.lua
+++ b/lua/treesitter-context.lua
@@ -217,7 +217,7 @@ function M.enable()
 
   autocmd('DiagnosticChanged', vim.schedule_wrap(au_update))
 
-  autocmd('BufReadPost', function(args)
+  autocmd({ 'BufReadPost', 'FileType' }, function(args)
     attached[args.buf] = should_attach(args.buf)
   end)
 


### PR DESCRIPTION
## Problem

When opening nvim with a buffer that has no backing file e.g. `nvim <(curl example.com)` and/or when buffer has no filetype, context does not show which is good, however, when changing filetype with `set ft=lang` `nvim-treesitter-context` stays unattached.

I first initially ran into this when doing `nvim <large.json` and saw that no context was being displayed after I did `set ft=json`

## Solution

Try to attach on `FileType` as well.

---

I confirmed this fixes the problem stated above with `set ft=<lang>`

