### PR TITLE
fix: plugin creates cleared `NONE` highlight group

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,7 @@ separator if `separator` is set. By default it links to `FloatBorder`.
 
 Use the highlight groups `TreesitterContextBottom` and/or
 `TreesitterContextLineNumberBottom` to change the highlight of the last line of
-the context window. By default it links to `NONE`.
+the context window. By default it is cleared.
 However, you can use this to create a border by applying an underline highlight, e.g,
 for an underline across the screen:
 

--- a/doc/nvim-treesitter-context.txt
+++ b/doc/nvim-treesitter-context.txt
@@ -86,7 +86,7 @@ HIGHLIGHTS                                  *nvim-treesitter-context-highlights*
     Used for the colors of the separator if `separator` is set.
 
 `TreesitterContextBottom`                             *hl-TreesitterContextBottom*
-    (default: links to `NONE`)
+    (default: cleared)
 
     Use for the last line of the context.
 

--- a/plugin/treesitter-context.lua
+++ b/plugin/treesitter-context.lua
@@ -12,7 +12,7 @@ end, {
 
 vim.api.nvim_set_hl(0, 'TreesitterContext', { link = 'NormalFloat', default = true })
 vim.api.nvim_set_hl(0, 'TreesitterContextLineNumber', { link = 'LineNr', default = true })
-vim.api.nvim_set_hl(0, 'TreesitterContextBottom', { link = 'NONE', default = true })
+vim.api.nvim_set_hl(0, 'TreesitterContextBottom', { default = true })
 vim.api.nvim_set_hl(
   0,
   'TreesitterContextLineNumberBottom',


### PR DESCRIPTION
Problem:
`TreesitterContextBottom` links to the non-existent `NONE` hl-group, which caused it to be created.

Solution:
Define `TreesitterContextBottom` as a cleared highlight group directly, avoiding creation of `NONE` hl-group. Update README and doc accordingly.