### PR TITLE
fix: invalid window id

### DIFF
--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -321,7 +321,7 @@ function M.get(winid)
   winid = winid or api.nvim_get_current_win()
 
   if not api.nvim_win_is_valid(winid) then
-    winid = api.nvim_get_current_win()
+    return
   end
 
   local bufnr = api.nvim_win_get_buf(winid)

--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -319,6 +319,11 @@ end
 --- @return Range4[]?, string[]?
 function M.get(winid)
   winid = winid or api.nvim_get_current_win()
+
+  if not api.nvim_win_is_valid(winid) then
+    winid = api.nvim_get_current_win()
+  end
+
   local bufnr = api.nvim_win_get_buf(winid)
 
   -- vim.treesitter.get_parser() calls bufload(), but we don't actually want to load the buffer:


### PR DESCRIPTION
When I use the fzf-lua plugin to preview search results for a string, it reports an invalid window id error
<img width="1271" height="698" alt="屏幕截图 2026-04-09 221155" src="https://github.com/user-attachments/assets/88f624f9-b2ad-4690-b45d-3d19cb4fb11e" />
