### PR TITLE
feat: pin context window

### DIFF
--- a/lua/treesitter-context/render.lua
+++ b/lua/treesitter-context/render.lua
@@ -66,6 +66,9 @@ local function display_window(winid, context_winid, width, height, col, ty, hl)
     vim.wo[context_winid].foldenable = false
     vim.wo[context_winid].winhl = 'NormalFloat:' .. hl
     vim.wo[context_winid].conceallevel = vim.wo[winid].conceallevel
+    if fn.exists('&winpinned') == 1 then
+      api.nvim_set_option_value('winpinned', true, { win = context_winid })
+    end
   elseif api.nvim_win_is_valid(context_winid) then
     api.nvim_win_set_config(context_winid, {
       win = winid,


### PR DESCRIPTION
Problem:
context windows could be closed by `:only` or `:fc` commands

Solution:
use the new window-local `winpinned` introduced in https://github.com/neovim/neovim/pull/39157
