### PR TITLE
fix: add more context support for c/cpp preprocessor directives

### DIFF
--- a/queries/c/context.scm
+++ b/queries/c/context.scm
@@ -6,6 +6,17 @@
   name: (identifier)
   (_) @context.end) @context
 
+(preproc_else
+  (_) @context.end) @context
+
+(preproc_elif
+  (_)
+  (_) @context.end) @context
+
+(preproc_elifdef
+  (_)
+  (_) @context.end) @context
+
 (function_definition
   body: (_
     (_) @context.end)) @context


### PR DESCRIPTION
Add more preprocessor directives for c/cpp, including `#elif`, `#elifdef`, `#elifndef` and `#else`.

See: https://cppreference.com/cpp/preprocessor/conditional