### PR TITLE
fix: parse() call for Neovim 0.10+ API

### DIFF
--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -235,9 +235,11 @@ local function get_parent_langtrees(bufnr, range)
     return {}
   end
 
-  local parse_ranges = vim.version().minor >= 10 and { range } or range
-  --- @diagnostic disable-next-line:redundant-parameter added in 0.11
-  root_tree:parse(parse_ranges, function(...) end)
+  local function try_parse(tree, r, cb)
+    local ok = pcall(function() tree:parse({ r }, cb) end)
+    if not ok then tree:parse(r, cb) end
+  end
+  try_parse(root_tree, range, function(...) end)
   local ret = { root_tree }
 
   while true do

--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -235,8 +235,9 @@ local function get_parent_langtrees(bufnr, range)
     return {}
   end
 
+  local range_arr = { range } --- @type Range4[]
   --- @diagnostic disable-next-line:redundant-parameter added in 0.11
-  root_tree:parse(range, function(...) end)
+  root_tree:parse(range_arr, function(...) end)
   local ret = { root_tree }
 
   while true do

--- a/lua/treesitter-context/context.lua
+++ b/lua/treesitter-context/context.lua
@@ -235,9 +235,9 @@ local function get_parent_langtrees(bufnr, range)
     return {}
   end
 
-  local range_arr = { range } --- @type Range4[]
+  local parse_ranges = vim.version().minor >= 10 and { range } or range
   --- @diagnostic disable-next-line:redundant-parameter added in 0.11
-  root_tree:parse(range_arr, function(...) end)
+  root_tree:parse(parse_ranges, function(...) end)
   local ret = { root_tree }
 
   while true do


### PR DESCRIPTION
## Summary

- Fixes the "attempt to call method range (a nil value)" error when moving the cursor in Neovim 0.10+
- Uses a version check to determine which parse() API to use

## Details

In Neovim 0.10+, LanguageTree:parse() requires an array of ranges instead of a single Range4 table. Added a version check (`vim.version().minor >= 10`) to use:
- `{ range }` array for Neovim 0.10+
- `range` single value for Neovim 0.9

This ensures full backwards compatibility with both versions.